### PR TITLE
Switch to Boost.Core's lightweight_test

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -7,61 +7,32 @@
 # Boost
 ###############################################################################
 set(Boost_USE_STATIC_LIBS ON)
-find_package(Boost 1.64.0 COMPONENTS ${boost_components})
-if (Boost_INCLUDE_DIR)
-  add_library(boost INTERFACE)
-  target_include_directories(boost INTERFACE ${Boost_INCLUDE_DIR})
-else ()
-  if (NOT BOOST_BRANCH)
-    set(BOOST_BRANCH master)
-  endif()
-  message("-- Boost was not found; it will be cloned locally from ${BOOST_BRANCH}.")
-  add_custom_target(
-    boost_root_clone
-    git clone --depth 100 -b ${BOOST_BRANCH}
-      https://github.com/boostorg/boost.git boost_root
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-  if (MSVC)
-    set(bootstrap_cmd ./bootstrap.bat)
-  else()
-    set(bootstrap_cmd ./bootstrap.sh)
-  endif()
-  add_custom_target(
-    boost_clone
-    COMMAND git submodule init libs/test
-    COMMAND git submodule init libs/algorithm
-    COMMAND git submodule init libs/bind
-    COMMAND git submodule init libs/container_hash
-    COMMAND git submodule init libs/exception
-    COMMAND git submodule init libs/function
-    COMMAND git submodule init libs/integer
-    COMMAND git submodule init libs/io
-    COMMAND git submodule init libs/iterator
-    COMMAND git submodule init libs/move
-    COMMAND git submodule init libs/mpl
-    COMMAND git submodule init libs/numeric
-    COMMAND git submodule init libs/preprocessor
-    COMMAND git submodule init libs/range
-    COMMAND git submodule init libs/smart_ptr
-    COMMAND git submodule init libs/static_assert
-    COMMAND git submodule init libs/type_index
-    COMMAND git submodule init libs/type_traits
-    COMMAND git submodule init libs/throw_exception
-    COMMAND git submodule init libs/utility
-    COMMAND git submodule init libs/assert
-    COMMAND git submodule init libs/config
-    COMMAND git submodule init libs/core
-    COMMAND git submodule init libs/predef
-    COMMAND git submodule init libs/detail
-    COMMAND git submodule init tools/build
-    COMMAND git submodule init libs/headers
-    COMMAND git submodule init tools/boost_install
-    COMMAND git submodule update --jobs 3
-    COMMAND ${bootstrap_cmd}
-    COMMAND ./b2 headers
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost_root
-    DEPENDS boost_root_clone)
-  add_library(boost INTERFACE)
-  add_dependencies(boost boost_clone)
-  target_include_directories(boost INTERFACE ${CMAKE_BINARY_DIR}/boost_root)
-endif ()
+if (NOT BOOST_BRANCH)
+  set(BOOST_BRANCH master)
+endif()
+add_custom_target(
+  boost_root_clone
+  git clone --depth 100 -b ${BOOST_BRANCH}
+    https://github.com/boostorg/boost.git boost_root
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+if (MSVC)
+  set(bootstrap_cmd ./bootstrap.bat)
+else()
+  set(bootstrap_cmd ./bootstrap.sh)
+endif()
+add_custom_target(
+  boost_clone
+  COMMAND git submodule init libs/assert
+  COMMAND git submodule init libs/config
+  COMMAND git submodule init libs/core
+  COMMAND git submodule init tools/build
+  COMMAND git submodule init libs/headers
+  COMMAND git submodule init tools/boost_install
+  COMMAND git submodule update --jobs 3
+  COMMAND ${bootstrap_cmd}
+  COMMAND ./b2 headers
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/boost_root
+  DEPENDS boost_root_clone)
+add_library(boost INTERFACE)
+add_dependencies(boost boost_clone)
+target_include_directories(boost INTERFACE ${CMAKE_BINARY_DIR}/boost_root)

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -9,23 +9,18 @@
 import testing ;
 import ../../config/checks/config : requires ;
 
-project boost/stl_interfaces/test :
+project :
     requirements
-        <library>../../test/build//boost_unit_test_framework
-        <link>static
         [ requires cxx14_constexpr ]
 ;
 
-test-suite all :
-[ run forward.cpp : : : : ]
-[ run detail.cpp : : : : ]
-[ run array.cpp : : : : ]
-[ run output.cpp : : : : ]
-[ run input.cpp : : : : ]
-[ run reverse_iter.cpp : : : : ]
-[ run static_vec_noncopyable.cpp : : : : ]
-[ run bidirectional.cpp : : : : ]
-[ run random_access.cpp : : : : ]
-[ run static_vec.cpp : : : : ]
-;
-
+run forward.cpp ;
+run detail.cpp ;
+run array.cpp ;
+run output.cpp ;
+run input.cpp ;
+run reverse_iter.cpp ;
+run static_vec_noncopyable.cpp ;
+run bidirectional.cpp ;
+run random_access.cpp ;
+run static_vec.cpp ;

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -7,8 +7,7 @@
 
 #include "ill_formed.hpp"
 
-#define BOOST_TEST_MAIN
-#include <boost/test/included/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <array>
 #include <deque>
@@ -63,7 +62,7 @@ struct array : boost::stl_interfaces::sequence_container_interface<
 using arr_type = array<int, 5>;
 
 
-BOOST_AUTO_TEST_CASE(comparisons)
+void test_comparisons()
 {
     arr_type sm;
     sm[0] = 1;
@@ -84,75 +83,75 @@ BOOST_AUTO_TEST_CASE(comparisons)
     lg[3] = 4;
     lg[4] = 5;
 
-    BOOST_CHECK(sm == sm);
-    BOOST_CHECK(!(sm == md));
-    BOOST_CHECK(!(sm == lg));
+    BOOST_TEST(sm == sm);
+    BOOST_TEST(!(sm == md));
+    BOOST_TEST(!(sm == lg));
 
-    BOOST_CHECK(!(sm != sm));
-    BOOST_CHECK(sm != md);
-    BOOST_CHECK(sm != lg);
+    BOOST_TEST(!(sm != sm));
+    BOOST_TEST(sm != md);
+    BOOST_TEST(sm != lg);
 
-    BOOST_CHECK(!(sm < sm));
-    BOOST_CHECK(sm < md);
-    BOOST_CHECK(sm < lg);
+    BOOST_TEST(!(sm < sm));
+    BOOST_TEST(sm < md);
+    BOOST_TEST(sm < lg);
 
-    BOOST_CHECK(sm <= sm);
-    BOOST_CHECK(sm <= md);
-    BOOST_CHECK(sm <= lg);
+    BOOST_TEST(sm <= sm);
+    BOOST_TEST(sm <= md);
+    BOOST_TEST(sm <= lg);
 
-    BOOST_CHECK(!(sm > sm));
-    BOOST_CHECK(!(sm > md));
-    BOOST_CHECK(!(sm > lg));
+    BOOST_TEST(!(sm > sm));
+    BOOST_TEST(!(sm > md));
+    BOOST_TEST(!(sm > lg));
 
-    BOOST_CHECK(sm >= sm);
-    BOOST_CHECK(!(sm >= md));
-    BOOST_CHECK(!(sm >= lg));
-
-
-    BOOST_CHECK(!(md == sm));
-    BOOST_CHECK(md == md);
-    BOOST_CHECK(!(md == lg));
-
-    BOOST_CHECK(!(md < sm));
-    BOOST_CHECK(!(md < md));
-    BOOST_CHECK(md < lg);
-
-    BOOST_CHECK(!(md <= sm));
-    BOOST_CHECK(md <= md);
-    BOOST_CHECK(md <= lg);
-
-    BOOST_CHECK(md > sm);
-    BOOST_CHECK(!(md > md));
-    BOOST_CHECK(!(md > lg));
-
-    BOOST_CHECK(md >= sm);
-    BOOST_CHECK(md >= md);
-    BOOST_CHECK(!(md >= lg));
+    BOOST_TEST(sm >= sm);
+    BOOST_TEST(!(sm >= md));
+    BOOST_TEST(!(sm >= lg));
 
 
-    BOOST_CHECK(!(lg == sm));
-    BOOST_CHECK(!(lg == md));
-    BOOST_CHECK(lg == lg);
+    BOOST_TEST(!(md == sm));
+    BOOST_TEST(md == md);
+    BOOST_TEST(!(md == lg));
 
-    BOOST_CHECK(!(lg < sm));
-    BOOST_CHECK(!(lg < md));
-    BOOST_CHECK(!(lg < lg));
+    BOOST_TEST(!(md < sm));
+    BOOST_TEST(!(md < md));
+    BOOST_TEST(md < lg);
 
-    BOOST_CHECK(!(lg <= sm));
-    BOOST_CHECK(!(lg <= md));
-    BOOST_CHECK(lg <= lg);
+    BOOST_TEST(!(md <= sm));
+    BOOST_TEST(md <= md);
+    BOOST_TEST(md <= lg);
 
-    BOOST_CHECK(lg > sm);
-    BOOST_CHECK(lg > md);
-    BOOST_CHECK(!(lg > lg));
+    BOOST_TEST(md > sm);
+    BOOST_TEST(!(md > md));
+    BOOST_TEST(!(md > lg));
 
-    BOOST_CHECK(lg >= sm);
-    BOOST_CHECK(lg >= md);
-    BOOST_CHECK(lg >= lg);
+    BOOST_TEST(md >= sm);
+    BOOST_TEST(md >= md);
+    BOOST_TEST(!(md >= lg));
+
+
+    BOOST_TEST(!(lg == sm));
+    BOOST_TEST(!(lg == md));
+    BOOST_TEST(lg == lg);
+
+    BOOST_TEST(!(lg < sm));
+    BOOST_TEST(!(lg < md));
+    BOOST_TEST(!(lg < lg));
+
+    BOOST_TEST(!(lg <= sm));
+    BOOST_TEST(!(lg <= md));
+    BOOST_TEST(lg <= lg);
+
+    BOOST_TEST(lg > sm);
+    BOOST_TEST(lg > md);
+    BOOST_TEST(!(lg > lg));
+
+    BOOST_TEST(lg >= sm);
+    BOOST_TEST(lg >= md);
+    BOOST_TEST(lg >= lg);
 }
 
 
-BOOST_AUTO_TEST_CASE(swap_)
+void test_swap()
 {
     {
         arr_type v1;
@@ -176,8 +175,8 @@ BOOST_AUTO_TEST_CASE(swap_)
 
         v1.swap(v2);
 
-        BOOST_CHECK(v1 == v2_copy);
-        BOOST_CHECK(v2 == v1_copy);
+        BOOST_TEST(v1 == v2_copy);
+        BOOST_TEST(v2 == v1_copy);
     }
 
     {
@@ -199,8 +198,8 @@ BOOST_AUTO_TEST_CASE(swap_)
 
         swap(v1, v2);
 
-        BOOST_CHECK(v1 == v2_copy);
-        BOOST_CHECK(v2 == v1_copy);
+        BOOST_TEST(v1 == v2_copy);
+        BOOST_TEST(v2 == v1_copy);
     }
 }
 
@@ -257,7 +256,7 @@ static_assert(
         value,
     "");
 
-BOOST_AUTO_TEST_CASE(iterators)
+void test_iterators()
 {
     arr_type v0;
     v0[0] = 3;
@@ -301,11 +300,11 @@ BOOST_AUTO_TEST_CASE(iterators)
         std::array<int, 5> const a = {{3, 2, 1, 0, 0}};
         std::array<int, 5> const ra = {{0, 0, 1, 2, 3}};
 
-        BOOST_CHECK(std::equal(v.begin(), v.end(), a.begin(), a.end()));
-        BOOST_CHECK(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.begin(), v.end(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
 
-        BOOST_CHECK(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
-        BOOST_CHECK(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
 
         arr_type v2;
         v2[0] = 8;
@@ -316,7 +315,7 @@ BOOST_AUTO_TEST_CASE(iterators)
 
         *v.begin() = 8;
         *v.rbegin() = 9;
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
@@ -358,11 +357,11 @@ BOOST_AUTO_TEST_CASE(iterators)
         std::array<int, 5> const a = {{3, 2, 1, 0, 0}};
         std::array<int, 5> const ra = {{0, 0, 1, 2, 3}};
 
-        BOOST_CHECK(std::equal(v.begin(), v.end(), a.begin(), a.end()));
-        BOOST_CHECK(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.begin(), v.end(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
 
-        BOOST_CHECK(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
-        BOOST_CHECK(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
     }
 }
 
@@ -413,7 +412,7 @@ static_assert(!ill_formed<rvalue_push_back_t, std_vec_int>::value, "");
 static_assert(!ill_formed<pop_back_t, std_vec_int>::value, "");
 
 
-BOOST_AUTO_TEST_CASE(front_back)
+void test_front_back()
 {
     {
         arr_type v;
@@ -428,8 +427,8 @@ BOOST_AUTO_TEST_CASE(front_back)
 
         v.front() = 9;
         v.back() = 8;
-        BOOST_CHECK(v[0] == v.front());
-        BOOST_CHECK(v[4] == v.back());
+        BOOST_TEST(v[0] == v.front());
+        BOOST_TEST(v[4] == v.back());
     }
 
     {
@@ -441,8 +440,8 @@ BOOST_AUTO_TEST_CASE(front_back)
         v0[4] = 1;
 
         arr_type const v = v0;
-        BOOST_CHECK(v.front() == 3);
-        BOOST_CHECK(v.back() == 1);
+        BOOST_TEST(v.front() == 3);
+        BOOST_TEST(v.back() == 1);
 
         static_assert(
             std::is_same<decltype(v.front()), int const &>::value, "");
@@ -451,7 +450,7 @@ BOOST_AUTO_TEST_CASE(front_back)
 }
 
 
-BOOST_AUTO_TEST_CASE(cindex_at)
+void test_cindex_at()
 {
     arr_type v0;
     v0[0] = 3;
@@ -462,32 +461,32 @@ BOOST_AUTO_TEST_CASE(cindex_at)
 
     {
         arr_type v = v0;
-        BOOST_CHECK(v[0] == 3);
-        BOOST_CHECK(v[1] == 2);
-        BOOST_CHECK(v[2] == 1);
-        BOOST_CHECK_NO_THROW(v.at(0));
-        BOOST_CHECK_NO_THROW(v.at(1));
-        BOOST_CHECK_NO_THROW(v.at(2));
-        BOOST_CHECK_THROW(v.at(5), std::out_of_range);
+        BOOST_TEST(v[0] == 3);
+        BOOST_TEST(v[1] == 2);
+        BOOST_TEST(v[2] == 1);
+        BOOST_TEST_NO_THROW(v.at(0));
+        BOOST_TEST_NO_THROW(v.at(1));
+        BOOST_TEST_NO_THROW(v.at(2));
+        BOOST_TEST_THROWS(v.at(5), std::out_of_range);
 
         static_assert(std::is_same<decltype(v[0]), int &>::value, "");
         static_assert(std::is_same<decltype(v.at(0)), int &>::value, "");
 
         v[0] = 8;
         v.at(1) = 9;
-        BOOST_CHECK(v[0] == 8);
-        BOOST_CHECK(v[1] == 9);
+        BOOST_TEST(v[0] == 8);
+        BOOST_TEST(v[1] == 9);
     }
 
     {
         arr_type const v = v0;
-        BOOST_CHECK(v[0] == 3);
-        BOOST_CHECK(v[1] == 2);
-        BOOST_CHECK(v[2] == 1);
-        BOOST_CHECK_NO_THROW(v.at(0));
-        BOOST_CHECK_NO_THROW(v.at(1));
-        BOOST_CHECK_NO_THROW(v.at(2));
-        BOOST_CHECK_THROW(v.at(5), std::out_of_range);
+        BOOST_TEST(v[0] == 3);
+        BOOST_TEST(v[1] == 2);
+        BOOST_TEST(v[2] == 1);
+        BOOST_TEST_NO_THROW(v.at(0));
+        BOOST_TEST_NO_THROW(v.at(1));
+        BOOST_TEST_NO_THROW(v.at(2));
+        BOOST_TEST_THROWS(v.at(5), std::out_of_range);
 
         static_assert(std::is_same<decltype(v[0]), int const &>::value, "");
         static_assert(std::is_same<decltype(v.at(0)), int const &>::value, "");
@@ -578,3 +577,13 @@ using clear_t = decltype(std::declval<Container &>().clear());
 static_assert(ill_formed<clear_t, arr_type>::value, "");
 
 static_assert(!ill_formed<clear_t, std_vec_int>::value, "");
+
+int main()
+{
+    test_comparisons();
+    test_swap();
+    test_iterators();
+    test_front_back();
+    test_cindex_at();
+    return boost::report_errors();
+}

--- a/test/bidirectional.cpp
+++ b/test/bidirectional.cpp
@@ -7,8 +7,9 @@
 
 #include "ill_formed.hpp"
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 
+#include <algorithm>
 #include <array>
 #include <numeric>
 #include <list>
@@ -326,7 +327,7 @@ static_assert(
     "");
 
 
-int test_main(int, char * [])
+int main()
 {
 
 {
@@ -336,7 +337,7 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -346,7 +347,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             ints_copy.begin());
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -354,7 +355,7 @@ int test_main(int, char * [])
         basic_bidirectional_iter first(iota_ints.data());
         basic_bidirectional_iter last(iota_ints.data() + iota_ints.size());
         std::iota(first, last, 0);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -366,7 +367,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::reverse(iota_ints.begin(), iota_ints.end());
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 }
 
@@ -378,7 +379,7 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -388,7 +389,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             ints_copy.begin());
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -397,7 +398,7 @@ int test_main(int, char * [])
         basic_adapted_bidirectional_ptr_iter last(
             iota_ints.data() + iota_ints.size());
         std::iota(first, last, 0);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -410,7 +411,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::reverse(iota_ints.begin(), iota_ints.end());
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 }
 
@@ -424,7 +425,7 @@ int test_main(int, char * [])
     {
         std::list<int> ints_copy;
         std::copy(first, last, std::back_inserter(ints_copy));
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -434,7 +435,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             std::back_inserter(ints_copy));
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 }
 
@@ -467,10 +468,10 @@ int test_main(int, char * [])
         const_bidirectional first_const(first);
         const_bidirectional last_const(last);
 
-        BOOST_CHECK(first == first_const);
-        BOOST_CHECK(first_const == first);
-        BOOST_CHECK(first != last_const);
-        BOOST_CHECK(last_const != first);
+        BOOST_TEST(first == first_const);
+        BOOST_TEST(first_const == first);
+        BOOST_TEST(first != last_const);
+        BOOST_TEST(last_const != first);
     }
 
     {
@@ -486,10 +487,10 @@ int test_main(int, char * [])
                 adapted_bidirectional_ptr_iter<int>>::value,
             "");
 
-        BOOST_CHECK(first == first_const);
-        BOOST_CHECK(first_const == first);
-        BOOST_CHECK(first != last_const);
-        BOOST_CHECK(last_const != first);
+        BOOST_TEST(first == first_const);
+        BOOST_TEST(first_const == first);
+        BOOST_TEST(first != last_const);
+        BOOST_TEST(last_const != first);
     }
 }
 
@@ -562,7 +563,7 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -572,7 +573,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             ints_copy.begin());
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -580,7 +581,7 @@ int test_main(int, char * [])
         bidirectional first(iota_ints.data());
         bidirectional last(iota_ints.data() + iota_ints.size());
         std::iota(first, last, 0);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -592,7 +593,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::reverse(iota_ints.begin(), iota_ints.end());
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 }
 
@@ -604,12 +605,12 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
-        BOOST_CHECK(std::binary_search(first, last, 3));
-        BOOST_CHECK(std::binary_search(
+        BOOST_TEST(std::binary_search(first, last, 3));
+        BOOST_TEST(std::binary_search(
             std::make_reverse_iterator(last),
             std::make_reverse_iterator(first),
             3,
@@ -631,38 +632,38 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(r.begin(), r.end(), ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
 
-        BOOST_CHECK(empty.begin() == empty.end());
+        BOOST_TEST(empty.begin() == empty.end());
     }
 
     // empty/op bool
     {
-        BOOST_CHECK(!r.empty());
-        BOOST_CHECK(r);
+        BOOST_TEST(!r.empty());
+        BOOST_TEST(r);
 
-        BOOST_CHECK(empty.empty());
-        BOOST_CHECK(!empty);
+        BOOST_TEST(empty.empty());
+        BOOST_TEST(!empty);
 
         auto const cr = r;
-        BOOST_CHECK(!cr.empty());
-        BOOST_CHECK(cr);
+        BOOST_TEST(!cr.empty());
+        BOOST_TEST(cr);
 
         auto const cempty = empty;
-        BOOST_CHECK(cempty.empty());
-        BOOST_CHECK(!cempty);
+        BOOST_TEST(cempty.empty());
+        BOOST_TEST(!cempty);
     }
 
     // front/back
     {
-        BOOST_CHECK(r.front() == 0);
-        BOOST_CHECK(r.back() == 9);
+        BOOST_TEST(r.front() == 0);
+        BOOST_TEST(r.back() == 9);
 
         auto const cr = r;
-        BOOST_CHECK(cr.front() == 0);
-        BOOST_CHECK(cr.back() == 9);
+        BOOST_TEST(cr.front() == 0);
+        BOOST_TEST(cr.back() == 9);
     }
 }
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/detail.cpp
+++ b/test/detail.cpp
@@ -7,9 +7,7 @@
 #include <boost/stl_interfaces/view_interface.hpp>
 #include <boost/stl_interfaces/sequence_container_interface.hpp>
 
-#include <boost/mpl/assert.hpp>
-
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <array>
 #include <list>
@@ -21,14 +19,14 @@ namespace v1_dtl = boost::stl_interfaces::v1::v1_dtl;
 
 
 // iter_difference_t
-BOOST_MPL_ASSERT(
-    (std::is_same<v1_dtl::iter_difference_t<int *>, std::ptrdiff_t>));
-BOOST_MPL_ASSERT((std::is_same<
+static_assert(
+    std::is_same<v1_dtl::iter_difference_t<int *>, std::ptrdiff_t>::value, "");
+static_assert(std::is_same<
                   v1_dtl::iter_difference_t<std::vector<double>::iterator>,
-                  std::vector<double>::difference_type>));
-BOOST_MPL_ASSERT((std::is_same<
+                  std::vector<double>::difference_type>::value, "");
+static_assert(std::is_same<
                   v1_dtl::iter_difference_t<std::list<double>::iterator>,
-                  std::list<double>::difference_type>));
+                  std::list<double>::difference_type>::value, "");
 
 struct ridiculous_range
 {
@@ -37,35 +35,35 @@ struct ridiculous_range
 };
 
 // iterator_t
-BOOST_MPL_ASSERT((std::is_same<
+static_assert(std::is_same<
                   v1_dtl::iterator_t<std::vector<double>>,
-                  std::vector<double>::iterator>));
-BOOST_MPL_ASSERT((std::is_same<
+                  std::vector<double>::iterator>::value, "");
+static_assert(std::is_same<
                   v1_dtl::iterator_t<std::list<double>>,
-                  std::list<double>::iterator>));
-BOOST_MPL_ASSERT((std::is_same<v1_dtl::iterator_t<ridiculous_range>, int *>));
+                  std::list<double>::iterator>::value, "");
+static_assert(std::is_same<v1_dtl::iterator_t<ridiculous_range>, int *>::value, "");
 
 // sentinel_t
-BOOST_MPL_ASSERT((std::is_same<
+static_assert(std::is_same<
                   v1_dtl::sentinel_t<std::vector<double>>,
-                  std::vector<double>::iterator>));
-BOOST_MPL_ASSERT((std::is_same<
+                  std::vector<double>::iterator>::value, "");
+static_assert(std::is_same<
                   v1_dtl::sentinel_t<std::list<double>>,
-                  std::list<double>::iterator>));
-BOOST_MPL_ASSERT((std::is_same<v1_dtl::sentinel_t<ridiculous_range>, double>));
+                  std::list<double>::iterator>::value, "");
+static_assert(std::is_same<v1_dtl::sentinel_t<ridiculous_range>, double>::value, "");
 
 // range_difference_t
-BOOST_MPL_ASSERT(
-    (std::is_same<
+static_assert(
+    std::is_same<
         v1_dtl::range_difference_t<std::vector<double>>,
-        std::iterator_traits<std::vector<double>::iterator>::difference_type>));
-BOOST_MPL_ASSERT(
-    (std::is_same<
+        std::iterator_traits<std::vector<double>::iterator>::difference_type>::value, "");
+static_assert(
+    std::is_same<
         v1_dtl::range_difference_t<std::list<double>>,
-        std::iterator_traits<std::list<double>::iterator>::difference_type>));
-BOOST_MPL_ASSERT((std::is_same<
+        std::iterator_traits<std::list<double>::iterator>::difference_type>::value, "");
+static_assert(std::is_same<
                   v1_dtl::range_difference_t<ridiculous_range>,
-                  std::ptrdiff_t>));
+                  std::ptrdiff_t>::value, "");
 
 // common_range
 static_assert(v1_dtl::common_range<std::vector<double>>::value, "");
@@ -76,7 +74,7 @@ static_assert(!v1_dtl::common_range<ridiculous_range>::value, "");
 struct no_clear
 {};
 
-int test_main(int, char * [])
+int main()
 {
 
 {
@@ -87,7 +85,7 @@ int test_main(int, char * [])
     {
         std::vector<int> vec(10);
         v1_dtl::clear_impl<std::vector<int>>::call(vec);
-        BOOST_CHECK(vec.empty());
+        BOOST_TEST(vec.empty());
     }
 }
 
@@ -98,8 +96,8 @@ int test_main(int, char * [])
     detail::n_iter<int, int> first = detail::make_n_iter(new_value, 3);
     detail::n_iter<int, int> last = detail::make_n_iter_end(new_value, 3);
     std::copy(first, last, &ints[1]);
-    BOOST_CHECK(ints == (std::array<int, 5>{{0, 6, 6, 6, 4}}));
+    BOOST_TEST(ints == (std::array<int, 5>{{0, 6, 6, 6, 4}}));
 }
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/forward.cpp
+++ b/test/forward.cpp
@@ -7,8 +7,9 @@
 
 #include "ill_formed.hpp"
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 
+#include <algorithm>
 #include <array>
 #include <numeric>
 #include <type_traits>
@@ -218,7 +219,7 @@ static_assert(
     "");
 
 
-int test_main(int, char * [])
+int main()
 {
 
 {
@@ -228,7 +229,7 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -236,7 +237,7 @@ int test_main(int, char * [])
         basic_forward_iter first(iota_ints.data());
         basic_forward_iter last(iota_ints.data() + iota_ints.size());
         std::iota(first, last, 0);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 }
 
@@ -265,7 +266,7 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -273,7 +274,7 @@ int test_main(int, char * [])
         forward first(iota_ints.data());
         forward last(iota_ints.data() + iota_ints.size());
         std::iota(first, last, 0);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 }
 
@@ -285,11 +286,11 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
-        BOOST_CHECK(std::binary_search(first, last, 3));
+        BOOST_TEST(std::binary_search(first, last, 3));
     }
 }
 
@@ -307,36 +308,36 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(r.begin(), r.end(), ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
 
-        BOOST_CHECK(empty.begin() == empty.end());
+        BOOST_TEST(empty.begin() == empty.end());
     }
 
     // empty/op bool
     {
-        BOOST_CHECK(!r.empty());
-        BOOST_CHECK(r);
+        BOOST_TEST(!r.empty());
+        BOOST_TEST(r);
 
-        BOOST_CHECK(empty.empty());
-        BOOST_CHECK(!empty);
+        BOOST_TEST(empty.empty());
+        BOOST_TEST(!empty);
 
         auto const cr = r;
-        BOOST_CHECK(!cr.empty());
-        BOOST_CHECK(cr);
+        BOOST_TEST(!cr.empty());
+        BOOST_TEST(cr);
 
         auto const cempty = empty;
-        BOOST_CHECK(cempty.empty());
-        BOOST_CHECK(!cempty);
+        BOOST_TEST(cempty.empty());
+        BOOST_TEST(!cempty);
     }
 
     // front/back
     {
-        BOOST_CHECK(r.front() == 0);
+        BOOST_TEST(r.front() == 0);
 
         auto const cr = r;
-        BOOST_CHECK(cr.front() == 0);
+        BOOST_TEST(cr.front() == 0);
     }
 }
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/input.cpp
+++ b/test/input.cpp
@@ -7,7 +7,7 @@
 
 #include "ill_formed.hpp"
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <array>
 #include <numeric>
@@ -263,7 +263,7 @@ static_assert(
     "");
 
 
-int test_main(int, char * [])
+int main()
 {
 
 {
@@ -273,7 +273,7 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 }
 
@@ -301,7 +301,7 @@ int test_main(int, char * [])
         int_input first(ints.data());
         int_input last(ints.data() + ints.size());
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -309,7 +309,7 @@ int test_main(int, char * [])
         pair_input first(pairs.data());
         pair_input last(pairs.data() + pairs.size());
         std::copy(first, last, pairs_copy.begin());
-        BOOST_CHECK(pairs_copy == pairs);
+        BOOST_TEST(pairs_copy == pairs);
     }
 
     {
@@ -319,7 +319,7 @@ int test_main(int, char * [])
         for (auto out = firsts_copy.begin(); first != last; ++first) {
             *out++ = first->first;
         }
-        BOOST_CHECK(firsts_copy == ints);
+        BOOST_TEST(firsts_copy == ints);
     }
 
     {
@@ -329,7 +329,7 @@ int test_main(int, char * [])
         for (auto out = firsts_copy.begin(); first != last; ++first) {
             *out++ = first->first;
         }
-        BOOST_CHECK(firsts_copy == ints);
+        BOOST_TEST(firsts_copy == ints);
     }
 }
 
@@ -340,7 +340,7 @@ int test_main(int, char * [])
         const_int_input first(ints.data());
         const_int_input last(ints.data() + ints.size());
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -348,7 +348,7 @@ int test_main(int, char * [])
         const_pair_input first(pairs.data());
         const_pair_input last(pairs.data() + pairs.size());
         std::copy(first, last, pairs_copy.begin());
-        BOOST_CHECK(pairs_copy == pairs);
+        BOOST_TEST(pairs_copy == pairs);
     }
 
     {
@@ -358,7 +358,7 @@ int test_main(int, char * [])
         for (auto out = firsts_copy.begin(); first != last; ++first) {
             *out++ = first->first;
         }
-        BOOST_CHECK(firsts_copy == ints);
+        BOOST_TEST(firsts_copy == ints);
     }
 
     {
@@ -369,7 +369,7 @@ int test_main(int, char * [])
         for (auto out = firsts_copy.begin(); first != last; ++first) {
             *out++ = first->first;
         }
-        BOOST_CHECK(firsts_copy == ints);
+        BOOST_TEST(firsts_copy == ints);
     }
 }
 
@@ -387,36 +387,36 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(r.begin(), r.end(), ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
 
-        BOOST_CHECK(empty.begin() == empty.end());
+        BOOST_TEST(empty.begin() == empty.end());
     }
 
     // empty/op bool
     {
-        BOOST_CHECK(!r.empty());
-        BOOST_CHECK(r);
+        BOOST_TEST(!r.empty());
+        BOOST_TEST(r);
 
-        BOOST_CHECK(empty.empty());
-        BOOST_CHECK(!empty);
+        BOOST_TEST(empty.empty());
+        BOOST_TEST(!empty);
 
         auto const cr = r;
-        BOOST_CHECK(!cr.empty());
-        BOOST_CHECK(cr);
+        BOOST_TEST(!cr.empty());
+        BOOST_TEST(cr);
 
         auto const cempty = empty;
-        BOOST_CHECK(cempty.empty());
-        BOOST_CHECK(!cempty);
+        BOOST_TEST(cempty.empty());
+        BOOST_TEST(!cempty);
     }
 
     // front/back
     {
-        BOOST_CHECK(r.front() == 0);
+        BOOST_TEST(r.front() == 0);
 
         auto const cr = r;
-        BOOST_CHECK(cr.front() == 0);
+        BOOST_TEST(cr.front() == 0);
     }
 }
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/output.cpp
+++ b/test/output.cpp
@@ -5,7 +5,7 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 #include <boost/stl_interfaces/iterator_interface.hpp>
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <array>
 #include <numeric>
@@ -102,20 +102,20 @@ BOOST_STL_INTERFACES_STATIC_ASSERT_ITERATOR_TRAITS(
 std::vector<int> ints = {{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}};
 
 
-int test_main(int, char * [])
+int main()
 {
 
 {
     std::vector<int> ints_copy(ints.size());
     std::copy(ints.begin(), ints.end(), output(&ints_copy[0]));
-    BOOST_CHECK(ints_copy == ints);
+    BOOST_TEST(ints_copy == ints);
 }
 
 
 {
     std::vector<int> ints_copy;
     std::copy(ints.begin(), ints.end(), back_insert(ints_copy));
-    BOOST_CHECK(ints_copy == ints);
+    BOOST_TEST(ints_copy == ints);
 }
 
 
@@ -126,5 +126,5 @@ int test_main(int, char * [])
         out++;
 }
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/random_access.cpp
+++ b/test/random_access.cpp
@@ -7,10 +7,12 @@
 
 #include "ill_formed.hpp"
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 
+#include <algorithm>
 #include <array>
 #include <numeric>
+#include <tuple>
 #include <type_traits>
 
 
@@ -392,51 +394,51 @@ static_assert(
     "");
 
 
-int test_main(int, char * [])
+int main()
 {
 
 {
     basic_random_access_iter first(ints.data());
     basic_random_access_iter last(ints.data() + ints.size());
 
-    BOOST_CHECK(*first == 0);
-    BOOST_CHECK(*(first + 1) == 1);
-    BOOST_CHECK(*(first + 2) == 2);
-    BOOST_CHECK(*(1 + first) == 1);
-    BOOST_CHECK(*(2 + first) == 2);
+    BOOST_TEST(*first == 0);
+    BOOST_TEST(*(first + 1) == 1);
+    BOOST_TEST(*(first + 2) == 2);
+    BOOST_TEST(*(1 + first) == 1);
+    BOOST_TEST(*(2 + first) == 2);
 
-    BOOST_CHECK(first[0] == 0);
-    BOOST_CHECK(first[1] == 1);
-    BOOST_CHECK(first[2] == 2);
+    BOOST_TEST(first[0] == 0);
+    BOOST_TEST(first[1] == 1);
+    BOOST_TEST(first[2] == 2);
 
-    BOOST_CHECK(*(last - 1) == 9);
-    BOOST_CHECK(*(last - 2) == 8);
-    BOOST_CHECK(*(last - 3) == 7);
+    BOOST_TEST(*(last - 1) == 9);
+    BOOST_TEST(*(last - 2) == 8);
+    BOOST_TEST(*(last - 3) == 7);
 
-    BOOST_CHECK(last[-1] == 9);
-    BOOST_CHECK(last[-2] == 8);
-    BOOST_CHECK(last[-3] == 7);
+    BOOST_TEST(last[-1] == 9);
+    BOOST_TEST(last[-2] == 8);
+    BOOST_TEST(last[-3] == 7);
 
-    BOOST_CHECK(last - first == 10);
-    BOOST_CHECK(first == first);
-    BOOST_CHECK(first != last);
-    BOOST_CHECK(first < last);
-    BOOST_CHECK(first <= last);
-    BOOST_CHECK(first <= first);
-    BOOST_CHECK(last > first);
-    BOOST_CHECK(last >= first);
-    BOOST_CHECK(last >= last);
+    BOOST_TEST(last - first == 10);
+    BOOST_TEST(first == first);
+    BOOST_TEST(first != last);
+    BOOST_TEST(first < last);
+    BOOST_TEST(first <= last);
+    BOOST_TEST(first <= first);
+    BOOST_TEST(last > first);
+    BOOST_TEST(last >= first);
+    BOOST_TEST(last >= last);
 
     {
         auto first_copy = first;
         first_copy += 10;
-        BOOST_CHECK(first_copy == last);
+        BOOST_TEST(first_copy == last);
     }
 
     {
         auto last_copy = last;
         last_copy -= 10;
-        BOOST_CHECK(last_copy == first);
+        BOOST_TEST(last_copy == first);
     }
 }
 
@@ -447,7 +449,7 @@ int test_main(int, char * [])
         basic_random_access_iter first(ints.data());
         basic_random_access_iter last(ints.data() + ints.size());
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -459,7 +461,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             ints_copy.begin());
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -467,7 +469,7 @@ int test_main(int, char * [])
         basic_random_access_iter first(iota_ints.data());
         basic_random_access_iter last(iota_ints.data() + iota_ints.size());
         std::iota(first, last, 0);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -479,7 +481,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::reverse(iota_ints.begin(), iota_ints.end());
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -491,7 +493,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::sort(first, last);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 }
 
@@ -500,44 +502,44 @@ int test_main(int, char * [])
     basic_adapted_random_access_iter first(ints.data());
     basic_adapted_random_access_iter last(ints.data() + ints.size());
 
-    BOOST_CHECK(*first == 0);
-    BOOST_CHECK(*(first + 1) == 1);
-    BOOST_CHECK(*(first + 2) == 2);
-    BOOST_CHECK(*(1 + first) == 1);
-    BOOST_CHECK(*(2 + first) == 2);
+    BOOST_TEST(*first == 0);
+    BOOST_TEST(*(first + 1) == 1);
+    BOOST_TEST(*(first + 2) == 2);
+    BOOST_TEST(*(1 + first) == 1);
+    BOOST_TEST(*(2 + first) == 2);
 
-    BOOST_CHECK(first[0] == 0);
-    BOOST_CHECK(first[1] == 1);
-    BOOST_CHECK(first[2] == 2);
+    BOOST_TEST(first[0] == 0);
+    BOOST_TEST(first[1] == 1);
+    BOOST_TEST(first[2] == 2);
 
-    BOOST_CHECK(*(last - 1) == 9);
-    BOOST_CHECK(*(last - 2) == 8);
-    BOOST_CHECK(*(last - 3) == 7);
+    BOOST_TEST(*(last - 1) == 9);
+    BOOST_TEST(*(last - 2) == 8);
+    BOOST_TEST(*(last - 3) == 7);
 
-    BOOST_CHECK(last[-1] == 9);
-    BOOST_CHECK(last[-2] == 8);
-    BOOST_CHECK(last[-3] == 7);
+    BOOST_TEST(last[-1] == 9);
+    BOOST_TEST(last[-2] == 8);
+    BOOST_TEST(last[-3] == 7);
 
-    BOOST_CHECK(last - first == 10);
-    BOOST_CHECK(first == first);
-    BOOST_CHECK(first != last);
-    BOOST_CHECK(first < last);
-    BOOST_CHECK(first <= last);
-    BOOST_CHECK(first <= first);
-    BOOST_CHECK(last > first);
-    BOOST_CHECK(last >= first);
-    BOOST_CHECK(last >= last);
+    BOOST_TEST(last - first == 10);
+    BOOST_TEST(first == first);
+    BOOST_TEST(first != last);
+    BOOST_TEST(first < last);
+    BOOST_TEST(first <= last);
+    BOOST_TEST(first <= first);
+    BOOST_TEST(last > first);
+    BOOST_TEST(last >= first);
+    BOOST_TEST(last >= last);
 
     {
         auto first_copy = first;
         first_copy += 10;
-        BOOST_CHECK(first_copy == last);
+        BOOST_TEST(first_copy == last);
     }
 
     {
         auto last_copy = last;
         last_copy -= 10;
-        BOOST_CHECK(last_copy == first);
+        BOOST_TEST(last_copy == first);
     }
 }
 
@@ -548,7 +550,7 @@ int test_main(int, char * [])
         basic_adapted_random_access_iter first(ints.data());
         basic_adapted_random_access_iter last(ints.data() + ints.size());
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -560,7 +562,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             ints_copy.begin());
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -569,7 +571,7 @@ int test_main(int, char * [])
         basic_adapted_random_access_iter last(
             iota_ints.data() + iota_ints.size());
         std::iota(first, last, 0);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -582,7 +584,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::reverse(iota_ints.begin(), iota_ints.end());
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -595,7 +597,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::sort(first, last);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 }
 
@@ -628,18 +630,18 @@ int test_main(int, char * [])
         const_random_access first_const(first);
         const_random_access last_const(last);
 
-        BOOST_CHECK(first == first_const);
-        BOOST_CHECK(first_const == first);
-        BOOST_CHECK(first != last_const);
-        BOOST_CHECK(last_const != first);
-        BOOST_CHECK(first <= first_const);
-        BOOST_CHECK(first_const <= first);
-        BOOST_CHECK(first >= first_const);
-        BOOST_CHECK(first_const >= first);
-        BOOST_CHECK(last_const > first);
-        BOOST_CHECK(last > first_const);
-        BOOST_CHECK(first_const < last);
-        BOOST_CHECK(first < last_const);
+        BOOST_TEST(first == first_const);
+        BOOST_TEST(first_const == first);
+        BOOST_TEST(first != last_const);
+        BOOST_TEST(last_const != first);
+        BOOST_TEST(first <= first_const);
+        BOOST_TEST(first_const <= first);
+        BOOST_TEST(first >= first_const);
+        BOOST_TEST(first_const >= first);
+        BOOST_TEST(last_const > first);
+        BOOST_TEST(last > first_const);
+        BOOST_TEST(first_const < last);
+        BOOST_TEST(first < last_const);
     }
 
     {
@@ -648,18 +650,18 @@ int test_main(int, char * [])
         adapted_random_access_iter<int const> first_const(first);
         adapted_random_access_iter<int const> last_const(last);
 
-        BOOST_CHECK(first == first_const);
-        BOOST_CHECK(first_const == first);
-        BOOST_CHECK(first != last_const);
-        BOOST_CHECK(last_const != first);
-        BOOST_CHECK(first <= first_const);
-        BOOST_CHECK(first_const <= first);
-        BOOST_CHECK(first >= first_const);
-        BOOST_CHECK(first_const >= first);
-        BOOST_CHECK(last_const > first);
-        BOOST_CHECK(last > first_const);
-        BOOST_CHECK(first_const < last);
-        BOOST_CHECK(first < last_const);
+        BOOST_TEST(first == first_const);
+        BOOST_TEST(first_const == first);
+        BOOST_TEST(first != last_const);
+        BOOST_TEST(last_const != first);
+        BOOST_TEST(first <= first_const);
+        BOOST_TEST(first_const <= first);
+        BOOST_TEST(first >= first_const);
+        BOOST_TEST(first_const >= first);
+        BOOST_TEST(last_const > first);
+        BOOST_TEST(last > first_const);
+        BOOST_TEST(first_const < last);
+        BOOST_TEST(first < last_const);
     }
 }
 
@@ -713,44 +715,44 @@ int test_main(int, char * [])
     random_access first(ints.data());
     random_access last(ints.data() + ints.size());
 
-    BOOST_CHECK(*first == 0);
-    BOOST_CHECK(*(first + 1) == 1);
-    BOOST_CHECK(*(first + 2) == 2);
-    BOOST_CHECK(*(1 + first) == 1);
-    BOOST_CHECK(*(2 + first) == 2);
+    BOOST_TEST(*first == 0);
+    BOOST_TEST(*(first + 1) == 1);
+    BOOST_TEST(*(first + 2) == 2);
+    BOOST_TEST(*(1 + first) == 1);
+    BOOST_TEST(*(2 + first) == 2);
 
-    BOOST_CHECK(first[0] == 0);
-    BOOST_CHECK(first[1] == 1);
-    BOOST_CHECK(first[2] == 2);
+    BOOST_TEST(first[0] == 0);
+    BOOST_TEST(first[1] == 1);
+    BOOST_TEST(first[2] == 2);
 
-    BOOST_CHECK(*(last - 1) == 9);
-    BOOST_CHECK(*(last - 2) == 8);
-    BOOST_CHECK(*(last - 3) == 7);
+    BOOST_TEST(*(last - 1) == 9);
+    BOOST_TEST(*(last - 2) == 8);
+    BOOST_TEST(*(last - 3) == 7);
 
-    BOOST_CHECK(last[-1] == 9);
-    BOOST_CHECK(last[-2] == 8);
-    BOOST_CHECK(last[-3] == 7);
+    BOOST_TEST(last[-1] == 9);
+    BOOST_TEST(last[-2] == 8);
+    BOOST_TEST(last[-3] == 7);
 
-    BOOST_CHECK(last - first == 10);
-    BOOST_CHECK(first == first);
-    BOOST_CHECK(first != last);
-    BOOST_CHECK(first < last);
-    BOOST_CHECK(first <= last);
-    BOOST_CHECK(first <= first);
-    BOOST_CHECK(last > first);
-    BOOST_CHECK(last >= first);
-    BOOST_CHECK(last >= last);
+    BOOST_TEST(last - first == 10);
+    BOOST_TEST(first == first);
+    BOOST_TEST(first != last);
+    BOOST_TEST(first < last);
+    BOOST_TEST(first <= last);
+    BOOST_TEST(first <= first);
+    BOOST_TEST(last > first);
+    BOOST_TEST(last >= first);
+    BOOST_TEST(last >= last);
 
     {
         auto first_copy = first;
         first_copy += 10;
-        BOOST_CHECK(first_copy == last);
+        BOOST_TEST(first_copy == last);
     }
 
     {
         auto last_copy = last;
         last_copy -= 10;
-        BOOST_CHECK(last_copy == first);
+        BOOST_TEST(last_copy == first);
     }
 }
 
@@ -762,7 +764,7 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -772,7 +774,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             ints_copy.begin());
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -780,7 +782,7 @@ int test_main(int, char * [])
         random_access first(iota_ints.data());
         random_access last(iota_ints.data() + iota_ints.size());
         std::iota(first, last, 0);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -792,7 +794,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::reverse(iota_ints.begin(), iota_ints.end());
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 
     {
@@ -804,7 +806,7 @@ int test_main(int, char * [])
             std::make_reverse_iterator(first),
             0);
         std::sort(first, last);
-        BOOST_CHECK(iota_ints == ints);
+        BOOST_TEST(iota_ints == ints);
     }
 }
 
@@ -816,12 +818,12 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(first, last, ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
-        BOOST_CHECK(std::binary_search(first, last, 3));
-        BOOST_CHECK(std::binary_search(
+        BOOST_TEST(std::binary_search(first, last, 3));
+        BOOST_TEST(std::binary_search(
             std::make_reverse_iterator(last),
             std::make_reverse_iterator(first),
             3,
@@ -834,7 +836,7 @@ int test_main(int, char * [])
     {
         zip_iter first(ints.data(), ones.data());
         zip_iter last(ints.data() + ints.size(), ones.data() + ones.size());
-        BOOST_CHECK(std::equal(first, last, tuples.begin(), tuples.end()));
+        BOOST_TEST(std::equal(first, last, tuples.begin(), tuples.end()));
     }
 
     {
@@ -845,15 +847,15 @@ int test_main(int, char * [])
         zip_iter last(
             ints_copy.data() + ints_copy.size(),
             ones_copy.data() + ones_copy.size());
-        BOOST_CHECK(!std::equal(first, last, tuples.begin(), tuples.end()));
+        BOOST_TEST(!std::equal(first, last, tuples.begin(), tuples.end()));
         std::sort(first, last);
-        BOOST_CHECK(std::equal(first, last, tuples.begin(), tuples.end()));
+        BOOST_TEST(std::equal(first, last, tuples.begin(), tuples.end()));
     }
 
     {
         udt_zip_iter first(udts.data(), ones.data());
         udt_zip_iter last(udts.data() + udts.size(), ones.data() + ones.size());
-        BOOST_CHECK(
+        BOOST_TEST(
             std::equal(first, last, udt_tuples.begin(), udt_tuples.end()));
     }
 
@@ -865,10 +867,10 @@ int test_main(int, char * [])
         udt_zip_iter last(
             udts_copy.data() + udts_copy.size(),
             ones_copy.data() + ones_copy.size());
-        BOOST_CHECK(
+        BOOST_TEST(
             !std::equal(first, last, udt_tuples.begin(), udt_tuples.end()));
         std::sort(first, last);
-        BOOST_CHECK(
+        BOOST_TEST(
             std::equal(first, last, udt_tuples.begin(), udt_tuples.end()));
     }
 }
@@ -886,72 +888,72 @@ int test_main(int, char * [])
     {
         std::array<int, 10> ints_copy;
         std::copy(r.begin(), r.end(), ints_copy.begin());
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
 
-        BOOST_CHECK(empty.begin() == empty.end());
+        BOOST_TEST(empty.begin() == empty.end());
     }
 
     // empty/op bool
     {
-        BOOST_CHECK(!r.empty());
-        BOOST_CHECK(r);
+        BOOST_TEST(!r.empty());
+        BOOST_TEST(r);
 
-        BOOST_CHECK(empty.empty());
-        BOOST_CHECK(!empty);
+        BOOST_TEST(empty.empty());
+        BOOST_TEST(!empty);
 
         auto const cr = r;
-        BOOST_CHECK(!cr.empty());
-        BOOST_CHECK(cr);
+        BOOST_TEST(!cr.empty());
+        BOOST_TEST(cr);
 
         auto const cempty = empty;
-        BOOST_CHECK(cempty.empty());
-        BOOST_CHECK(!cempty);
+        BOOST_TEST(cempty.empty());
+        BOOST_TEST(!cempty);
     }
 
     // data
     {
-        BOOST_CHECK(r.data() != nullptr);
-        BOOST_CHECK(r.data()[2] == 2);
+        BOOST_TEST(r.data() != nullptr);
+        BOOST_TEST(r.data()[2] == 2);
 
-        BOOST_CHECK(empty.data() != nullptr);
+        BOOST_TEST(empty.data() != nullptr);
 
         auto const cr = r;
-        BOOST_CHECK(cr.data() != nullptr);
-        BOOST_CHECK(cr.data()[2] == 2);
+        BOOST_TEST(cr.data() != nullptr);
+        BOOST_TEST(cr.data()[2] == 2);
 
         auto const cempty = empty;
-        BOOST_CHECK(cempty.data() != nullptr);
+        BOOST_TEST(cempty.data() != nullptr);
     }
 
     // size
     {
-        BOOST_CHECK(r.size() == 10u);
+        BOOST_TEST(r.size() == 10u);
 
-        BOOST_CHECK(empty.size() == 0u);
+        BOOST_TEST(empty.size() == 0u);
 
         auto const cr = r;
-        BOOST_CHECK(cr.size() == 10u);
+        BOOST_TEST(cr.size() == 10u);
 
         auto const cempty = empty;
-        BOOST_CHECK(cempty.size() == 0u);
+        BOOST_TEST(cempty.size() == 0u);
     }
 
     // front/back
     {
-        BOOST_CHECK(r.front() == 0);
-        BOOST_CHECK(r.back() == 9);
+        BOOST_TEST(r.front() == 0);
+        BOOST_TEST(r.back() == 9);
 
         auto const cr = r;
-        BOOST_CHECK(cr.front() == 0);
-        BOOST_CHECK(cr.back() == 9);
+        BOOST_TEST(cr.front() == 0);
+        BOOST_TEST(cr.back() == 9);
     }
 
     // op[]
     {
-        BOOST_CHECK(r[2] == 2);
+        BOOST_TEST(r[2] == 2);
 
         auto const cr = r;
-        BOOST_CHECK(cr[2] == 2);
+        BOOST_TEST(cr[2] == 2);
     }
 }
 
@@ -968,57 +970,57 @@ int test_main(int, char * [])
 
     // range begin/end
     {
-        BOOST_CHECK(std::equal(first, last, tuples.begin(), tuples.end()));
+        BOOST_TEST(std::equal(first, last, tuples.begin(), tuples.end()));
     }
 
     // empty/op bool
     {
-        BOOST_CHECK(!r.empty());
-        BOOST_CHECK(r);
+        BOOST_TEST(!r.empty());
+        BOOST_TEST(r);
 
-        BOOST_CHECK(empty.empty());
-        BOOST_CHECK(!empty);
+        BOOST_TEST(empty.empty());
+        BOOST_TEST(!empty);
 
         auto const cr = r;
-        BOOST_CHECK(!cr.empty());
-        BOOST_CHECK(cr);
+        BOOST_TEST(!cr.empty());
+        BOOST_TEST(cr);
 
         auto const cempty = empty;
-        BOOST_CHECK(cempty.empty());
-        BOOST_CHECK(!cempty);
+        BOOST_TEST(cempty.empty());
+        BOOST_TEST(!cempty);
     }
 
     // size
     {
-        BOOST_CHECK(r.size() == 10u);
+        BOOST_TEST(r.size() == 10u);
 
-        BOOST_CHECK(empty.size() == 0u);
+        BOOST_TEST(empty.size() == 0u);
 
         auto const cr = r;
-        BOOST_CHECK(cr.size() == 10u);
+        BOOST_TEST(cr.size() == 10u);
 
         auto const cempty = empty;
-        BOOST_CHECK(cempty.size() == 0u);
+        BOOST_TEST(cempty.size() == 0u);
     }
 
     // front/back
     {
-        BOOST_CHECK(r.front() == (std::tuple<int, int>(0, 1)));
-        BOOST_CHECK(r.back() == (std::tuple<int, int>(9, 1)));
+        BOOST_TEST(r.front() == (std::tuple<int, int>(0, 1)));
+        BOOST_TEST(r.back() == (std::tuple<int, int>(9, 1)));
 
         auto const cr = r;
-        BOOST_CHECK(cr.front() == (std::tuple<int, int>(0, 1)));
-        BOOST_CHECK(cr.back() == (std::tuple<int, int>(9, 1)));
+        BOOST_TEST(cr.front() == (std::tuple<int, int>(0, 1)));
+        BOOST_TEST(cr.back() == (std::tuple<int, int>(9, 1)));
     }
 
     // op[]
     {
-        BOOST_CHECK(r[2] == (std::tuple<int, int>(2, 1)));
+        BOOST_TEST(r[2] == (std::tuple<int, int>(2, 1)));
 
         auto const cr = r;
-        BOOST_CHECK(cr[2] == (std::tuple<int, int>(2, 1)));
+        BOOST_TEST(cr[2] == (std::tuple<int, int>(2, 1)));
     }
 }
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/reverse_iter.cpp
+++ b/test/reverse_iter.cpp
@@ -6,11 +6,12 @@
 #include <boost/stl_interfaces/iterator_interface.hpp>
 #include <boost/stl_interfaces/reverse_iterator.hpp>
 
-#include <boost/test/minimal.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <algorithm>
 #include <array>
 #include <list>
+#include <tuple>
 #include <vector>
 
 
@@ -44,7 +45,7 @@ private:
 };
 
 
-int test_main(int, char * [])
+int main()
 {
 
 {
@@ -58,20 +59,20 @@ int test_main(int, char * [])
             std::list<int>::const_iterator>(first);
         auto clast = boost::stl_interfaces::reverse_iterator<
             std::list<int>::const_iterator>(last);
-        BOOST_CHECK(std::equal(first, last, cfirst, clast));
+        BOOST_TEST(std::equal(first, last, cfirst, clast));
     }
 
     {
         auto ints_copy = ints;
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(
+        BOOST_TEST(
             std::equal(first, last, ints_copy.begin(), ints_copy.end()));
     }
 
     {
         std::list<int> ints_copy;
         std::reverse_copy(first, last, std::back_inserter(ints_copy));
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -79,7 +80,7 @@ int test_main(int, char * [])
         for (auto it = first; it != last; ++it) {
             ++count;
         }
-        BOOST_CHECK(count == ints.size());
+        BOOST_TEST(count == ints.size());
     }
 
     {
@@ -87,7 +88,7 @@ int test_main(int, char * [])
         for (auto it = first; it != last; it++) {
             ++count;
         }
-        BOOST_CHECK(count == ints.size());
+        BOOST_TEST(count == ints.size());
     }
 
     {
@@ -95,7 +96,7 @@ int test_main(int, char * [])
         for (auto it = last; it != first; --it) {
             ++count;
         }
-        BOOST_CHECK(count == ints.size());
+        BOOST_TEST(count == ints.size());
     }
 
     {
@@ -103,7 +104,7 @@ int test_main(int, char * [])
         for (auto it = last; it != first; it--) {
             ++count;
         }
-        BOOST_CHECK(count == ints.size());
+        BOOST_TEST(count == ints.size());
     }
 }
 
@@ -119,21 +120,21 @@ int test_main(int, char * [])
             std::vector<int>::const_iterator>(first);
         auto clast = boost::stl_interfaces::reverse_iterator<
             std::vector<int>::const_iterator>(last);
-        BOOST_CHECK(std::equal(first, last, cfirst, clast));
+        BOOST_TEST(std::equal(first, last, cfirst, clast));
     }
 
     {
         auto ints_copy = ints;
         std::reverse(ints_copy.begin(), ints_copy.end());
-        BOOST_CHECK(first - last == ints_copy.begin() - ints_copy.end());
-        BOOST_CHECK(
+        BOOST_TEST(first - last == ints_copy.begin() - ints_copy.end());
+        BOOST_TEST(
             std::equal(first, last, ints_copy.begin(), ints_copy.end()));
     }
 
     {
         std::vector<int> ints_copy;
         std::reverse_copy(first, last, std::back_inserter(ints_copy));
-        BOOST_CHECK(ints_copy == ints);
+        BOOST_TEST(ints_copy == ints);
     }
 
     {
@@ -141,7 +142,7 @@ int test_main(int, char * [])
         for (auto it = first; it != last; ++it) {
             ++count;
         }
-        BOOST_CHECK(count == ints.size());
+        BOOST_TEST(count == ints.size());
     }
 
     {
@@ -149,7 +150,7 @@ int test_main(int, char * [])
         for (auto it = first; it != last; it++) {
             ++count;
         }
-        BOOST_CHECK(count == ints.size());
+        BOOST_TEST(count == ints.size());
     }
 
     {
@@ -157,7 +158,7 @@ int test_main(int, char * [])
         for (auto it = last; it != first; --it) {
             ++count;
         }
-        BOOST_CHECK(count == ints.size());
+        BOOST_TEST(count == ints.size());
     }
 
     {
@@ -165,7 +166,7 @@ int test_main(int, char * [])
         for (auto it = last; it != first; it--) {
             ++count;
         }
-        BOOST_CHECK(count == ints.size());
+        BOOST_TEST(count == ints.size());
     }
 }
 
@@ -194,15 +195,15 @@ int test_main(int, char * [])
     {
         auto tuples_copy = tuples;
         std::reverse(tuples_copy.begin(), tuples_copy.end());
-        BOOST_CHECK(first - last == tuples_copy.begin() - tuples_copy.end());
-        BOOST_CHECK(
+        BOOST_TEST(first - last == tuples_copy.begin() - tuples_copy.end());
+        BOOST_TEST(
             std::equal(first, last, tuples_copy.begin(), tuples_copy.end()));
     }
 
     {
         std::array<std::tuple<int, int>, 10> tuples_copy;
         std::reverse_copy(first, last, tuples_copy.begin());
-        BOOST_CHECK(tuples_copy == tuples);
+        BOOST_TEST(tuples_copy == tuples);
     }
 
     {
@@ -210,7 +211,7 @@ int test_main(int, char * [])
         for (auto it = first; it != last; ++it) {
             ++count;
         }
-        BOOST_CHECK(count == tuples.size());
+        BOOST_TEST(count == tuples.size());
     }
 
     {
@@ -218,7 +219,7 @@ int test_main(int, char * [])
         for (auto it = first; it != last; it++) {
             ++count;
         }
-        BOOST_CHECK(count == tuples.size());
+        BOOST_TEST(count == tuples.size());
     }
 
     {
@@ -226,7 +227,7 @@ int test_main(int, char * [])
         for (auto it = last; it != first; --it) {
             ++count;
         }
-        BOOST_CHECK(count == tuples.size());
+        BOOST_TEST(count == tuples.size());
     }
 
     {
@@ -234,9 +235,9 @@ int test_main(int, char * [])
         for (auto it = last; it != first; it--) {
             ++count;
         }
-        BOOST_CHECK(count == tuples.size());
+        BOOST_TEST(count == tuples.size());
     }
 }
 
-    return 0;
+    return boost::report_errors();
 }

--- a/test/static_vec.cpp
+++ b/test/static_vec.cpp
@@ -7,8 +7,7 @@
 
 #include "ill_formed.hpp"
 
-#define BOOST_TEST_MAIN
-#include <boost/test/included/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <array>
 
@@ -18,104 +17,104 @@ template struct static_vector<int, 1024>;
 using vec_type = static_vector<int, 10>;
 
 
-BOOST_AUTO_TEST_CASE(default_ctor)
+void test_default_ctor()
 {
     vec_type v;
-    BOOST_CHECK(v.empty());
-    BOOST_CHECK(v.size() == 0u);
+    BOOST_TEST(v.empty());
+    BOOST_TEST(v.size() == 0u);
 
-    BOOST_CHECK(v.max_size() == 10u);
-    BOOST_CHECK(v.capacity() == 10u);
+    BOOST_TEST(v.max_size() == 10u);
+    BOOST_TEST(v.capacity() == 10u);
 
-    BOOST_CHECK(v == v);
-    BOOST_CHECK(v <= v);
-    BOOST_CHECK(v >= v);
+    BOOST_TEST(v == v);
+    BOOST_TEST(v <= v);
+    BOOST_TEST(v >= v);
 
-    BOOST_CHECK_THROW(v.at(0), std::out_of_range);
+    BOOST_TEST_THROWS(v.at(0), std::out_of_range);
 
     vec_type const & cv = v;
-    BOOST_CHECK(cv.empty());
-    BOOST_CHECK(cv.size() == 0u);
+    BOOST_TEST(cv.empty());
+    BOOST_TEST(cv.size() == 0u);
 
-    BOOST_CHECK(cv.max_size() == 10u);
-    BOOST_CHECK(cv.capacity() == 10u);
+    BOOST_TEST(cv.max_size() == 10u);
+    BOOST_TEST(cv.capacity() == 10u);
 
-    BOOST_CHECK(cv == cv);
-    BOOST_CHECK(cv <= cv);
-    BOOST_CHECK(cv >= cv);
+    BOOST_TEST(cv == cv);
+    BOOST_TEST(cv <= cv);
+    BOOST_TEST(cv >= cv);
 
-    BOOST_CHECK_THROW(cv.at(0), std::out_of_range);
+    BOOST_TEST_THROWS(cv.at(0), std::out_of_range);
 }
 
 
-BOOST_AUTO_TEST_CASE(other_ctors_assign_ctor)
+void test_other_ctors_assign_ctor()
 {
     {
         vec_type v(3);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         vec_type v2(std::initializer_list<int>{0, 0, 0});
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
         std::initializer_list<int> il{3, 2, 1};
         vec_type v(il);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         static_assert(std::is_same<decltype(v = il), vec_type &>::value, "");
 
         vec_type v2;
         v2 = il;
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
         std::initializer_list<int> il{3, 2, 1};
         vec_type v;
         v.assign(il);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         static_assert(std::is_same<decltype(v.assign(il)), void>::value, "");
 
         vec_type v2;
         v2 = il;
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
         vec_type v(3, 4);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         vec_type v2 = {4, 4, 4};
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
         vec_type v;
         v.assign(3, 4);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         static_assert(std::is_same<decltype(v.assign(3, 4)), void>::value, "");
 
         vec_type v2 = {4, 4, 4};
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
         std::array<int, 3> a = {{1, 2, 3}};
 
         vec_type v(a.begin(), a.end());
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         vec_type v2 = {1, 2, 3};
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
@@ -123,20 +122,20 @@ BOOST_AUTO_TEST_CASE(other_ctors_assign_ctor)
 
         vec_type v;
         v.assign(a.begin(), a.end());
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         static_assert(
             std::is_same<decltype(v.assign(a.begin(), a.end())), void>::value,
             "");
 
         vec_type v2 = {1, 2, 3};
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(resize)
+void test_resize()
 {
     {
         vec_type v;
@@ -144,31 +143,31 @@ BOOST_AUTO_TEST_CASE(resize)
         static_assert(std::is_same<decltype(v.resize(1)), void>::value, "");
 
         v.resize(3);
-        BOOST_CHECK(v == vec_type(3));
+        BOOST_TEST(v == vec_type(3));
 
         v.resize(6);
-        BOOST_CHECK(v == vec_type(6));
+        BOOST_TEST(v == vec_type(6));
     }
 
     {
         vec_type v(6);
 
         v.resize(3);
-        BOOST_CHECK(v == vec_type(3));
+        BOOST_TEST(v == vec_type(3));
 
         v.resize(0);
-        BOOST_CHECK(v == vec_type{});
+        BOOST_TEST(v == vec_type{});
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(assignment_copy_move_equality)
+void test_assignment_copy_move_equality()
 {
     {
         vec_type v2 = {4, 4, 4};
 
         vec_type v(v2);
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
@@ -180,15 +179,15 @@ BOOST_AUTO_TEST_CASE(assignment_copy_move_equality)
             std::is_same<decltype(v = std::move(v2)), vec_type &>::value, "");
 
         v = v2;
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
         vec_type v2 = {4, 4, 4};
 
         vec_type v(std::move(v2));
-        BOOST_CHECK(v == (vec_type(3, 4)));
-        BOOST_CHECK(v2.empty());
+        BOOST_TEST(v == (vec_type(3, 4)));
+        BOOST_TEST(v2.empty());
     }
 
     {
@@ -196,87 +195,87 @@ BOOST_AUTO_TEST_CASE(assignment_copy_move_equality)
         vec_type v2 = {4, 4, 4};
 
         v = std::move(v2);
-        BOOST_CHECK(v == (vec_type(3, 4)));
-        BOOST_CHECK(v2.empty());
+        BOOST_TEST(v == (vec_type(3, 4)));
+        BOOST_TEST(v2.empty());
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(comparisons)
+void test_comparisons()
 {
     vec_type sm = {1, 2, 3};
     vec_type md = {1, 2, 3, 4};
     vec_type lg = {1, 2, 3, 4, 5};
 
-    BOOST_CHECK(sm == sm);
-    BOOST_CHECK(!(sm == md));
-    BOOST_CHECK(!(sm == lg));
+    BOOST_TEST(sm == sm);
+    BOOST_TEST(!(sm == md));
+    BOOST_TEST(!(sm == lg));
 
-    BOOST_CHECK(!(sm != sm));
-    BOOST_CHECK(sm != md);
-    BOOST_CHECK(sm != lg);
+    BOOST_TEST(!(sm != sm));
+    BOOST_TEST(sm != md);
+    BOOST_TEST(sm != lg);
 
-    BOOST_CHECK(!(sm < sm));
-    BOOST_CHECK(sm < md);
-    BOOST_CHECK(sm < lg);
+    BOOST_TEST(!(sm < sm));
+    BOOST_TEST(sm < md);
+    BOOST_TEST(sm < lg);
 
-    BOOST_CHECK(sm <= sm);
-    BOOST_CHECK(sm <= md);
-    BOOST_CHECK(sm <= lg);
+    BOOST_TEST(sm <= sm);
+    BOOST_TEST(sm <= md);
+    BOOST_TEST(sm <= lg);
 
-    BOOST_CHECK(!(sm > sm));
-    BOOST_CHECK(!(sm > md));
-    BOOST_CHECK(!(sm > lg));
+    BOOST_TEST(!(sm > sm));
+    BOOST_TEST(!(sm > md));
+    BOOST_TEST(!(sm > lg));
 
-    BOOST_CHECK(sm >= sm);
-    BOOST_CHECK(!(sm >= md));
-    BOOST_CHECK(!(sm >= lg));
-
-
-    BOOST_CHECK(!(md == sm));
-    BOOST_CHECK(md == md);
-    BOOST_CHECK(!(md == lg));
-
-    BOOST_CHECK(!(md < sm));
-    BOOST_CHECK(!(md < md));
-    BOOST_CHECK(md < lg);
-
-    BOOST_CHECK(!(md <= sm));
-    BOOST_CHECK(md <= md);
-    BOOST_CHECK(md <= lg);
-
-    BOOST_CHECK(md > sm);
-    BOOST_CHECK(!(md > md));
-    BOOST_CHECK(!(md > lg));
-
-    BOOST_CHECK(md >= sm);
-    BOOST_CHECK(md >= md);
-    BOOST_CHECK(!(md >= lg));
+    BOOST_TEST(sm >= sm);
+    BOOST_TEST(!(sm >= md));
+    BOOST_TEST(!(sm >= lg));
 
 
-    BOOST_CHECK(!(lg == sm));
-    BOOST_CHECK(!(lg == md));
-    BOOST_CHECK(lg == lg);
+    BOOST_TEST(!(md == sm));
+    BOOST_TEST(md == md);
+    BOOST_TEST(!(md == lg));
 
-    BOOST_CHECK(!(lg < sm));
-    BOOST_CHECK(!(lg < md));
-    BOOST_CHECK(!(lg < lg));
+    BOOST_TEST(!(md < sm));
+    BOOST_TEST(!(md < md));
+    BOOST_TEST(md < lg);
 
-    BOOST_CHECK(!(lg <= sm));
-    BOOST_CHECK(!(lg <= md));
-    BOOST_CHECK(lg <= lg);
+    BOOST_TEST(!(md <= sm));
+    BOOST_TEST(md <= md);
+    BOOST_TEST(md <= lg);
 
-    BOOST_CHECK(lg > sm);
-    BOOST_CHECK(lg > md);
-    BOOST_CHECK(!(lg > lg));
+    BOOST_TEST(md > sm);
+    BOOST_TEST(!(md > md));
+    BOOST_TEST(!(md > lg));
 
-    BOOST_CHECK(lg >= sm);
-    BOOST_CHECK(lg >= md);
-    BOOST_CHECK(lg >= lg);
+    BOOST_TEST(md >= sm);
+    BOOST_TEST(md >= md);
+    BOOST_TEST(!(md >= lg));
+
+
+    BOOST_TEST(!(lg == sm));
+    BOOST_TEST(!(lg == md));
+    BOOST_TEST(lg == lg);
+
+    BOOST_TEST(!(lg < sm));
+    BOOST_TEST(!(lg < md));
+    BOOST_TEST(!(lg < lg));
+
+    BOOST_TEST(!(lg <= sm));
+    BOOST_TEST(!(lg <= md));
+    BOOST_TEST(lg <= lg);
+
+    BOOST_TEST(lg > sm);
+    BOOST_TEST(lg > md);
+    BOOST_TEST(!(lg > lg));
+
+    BOOST_TEST(lg >= sm);
+    BOOST_TEST(lg >= md);
+    BOOST_TEST(lg >= lg);
 }
 
 
-BOOST_AUTO_TEST_CASE(swap_)
+void test_swap()
 {
     {
         vec_type v1(3, 4);
@@ -287,11 +286,11 @@ BOOST_AUTO_TEST_CASE(swap_)
 
         v1.swap(v2);
 
-        BOOST_CHECK(v1.size() == 4u);
-        BOOST_CHECK(v2.size() == 3u);
+        BOOST_TEST(v1.size() == 4u);
+        BOOST_TEST(v2.size() == 3u);
 
-        BOOST_CHECK(v1 == vec_type(4, 3));
-        BOOST_CHECK(v2 == vec_type(3, 4));
+        BOOST_TEST(v1 == vec_type(4, 3));
+        BOOST_TEST(v2 == vec_type(3, 4));
     }
 
     {
@@ -300,11 +299,11 @@ BOOST_AUTO_TEST_CASE(swap_)
 
         swap(v1, v2);
 
-        BOOST_CHECK(v1.size() == 4u);
-        BOOST_CHECK(v2.size() == 3u);
+        BOOST_TEST(v1.size() == 4u);
+        BOOST_TEST(v2.size() == 3u);
 
-        BOOST_CHECK(v1 == vec_type(4, 3));
-        BOOST_CHECK(v2 == vec_type(3, 4));
+        BOOST_TEST(v1 == vec_type(4, 3));
+        BOOST_TEST(v2 == vec_type(3, 4));
     }
 }
 
@@ -352,7 +351,7 @@ static_assert(
         value,
     "");
 
-BOOST_AUTO_TEST_CASE(iterators)
+void test_iterators()
 {
     {
         vec_type v = {3, 2, 1};
@@ -389,15 +388,15 @@ BOOST_AUTO_TEST_CASE(iterators)
         std::array<int, 3> const a = {{3, 2, 1}};
 	std::array<int, 3> const ra = {{1, 2, 3}};
 
-        BOOST_CHECK(std::equal(v.begin(), v.end(), a.begin(), a.end()));
-        BOOST_CHECK(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.begin(), v.end(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
 
-        BOOST_CHECK(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
-        BOOST_CHECK(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
 
         *v.begin() = 8;
         *v.rbegin() = 9;
-        BOOST_CHECK(v == vec_type({8, 2, 9}));
+        BOOST_TEST(v == vec_type({8, 2, 9}));
     }
 
     {
@@ -439,16 +438,16 @@ BOOST_AUTO_TEST_CASE(iterators)
         std::array<int, 3> const a = {{3, 2, 1}};
         std::array<int, 3> const ra = {{1, 2, 3}};
 
-        BOOST_CHECK(std::equal(v.begin(), v.end(), a.begin(), a.end()));
-        BOOST_CHECK(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.begin(), v.end(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
 
-        BOOST_CHECK(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
-        BOOST_CHECK(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(emplace_insert)
+void test_emplace_insert()
 {
     {
         vec_type v;
@@ -464,18 +463,18 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         v.emplace_back(i);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == i);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == i);
 
         v.emplace_back(1);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == 1);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == 1);
 
         v.emplace_back(2);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == 2);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == 2);
 
-        BOOST_CHECK(v == vec_type({0, 1, 2}));
+        BOOST_TEST(v == vec_type({0, 1, 2}));
     }
 
     {
@@ -494,13 +493,13 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         v.emplace(v.begin(), i);
-        BOOST_CHECK(v == vec_type({0, 1, 2}));
+        BOOST_TEST(v == vec_type({0, 1, 2}));
 
         v.emplace(v.end(), 3);
-        BOOST_CHECK(v == vec_type({0, 1, 2, 3}));
+        BOOST_TEST(v == vec_type({0, 1, 2, 3}));
 
         v.emplace(v.begin() + 2, 9);
-        BOOST_CHECK(v == vec_type({0, 1, 9, 2, 3}));
+        BOOST_TEST(v == vec_type({0, 1, 9, 2, 3}));
     }
 
     {
@@ -517,16 +516,16 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         auto const it0 = v.insert(v.begin(), a1.begin(), a1.end());
-        BOOST_CHECK(v == vec_type({0, 0, 1, 2}));
-        BOOST_CHECK(it0 == v.begin());
+        BOOST_TEST(v == vec_type({0, 0, 1, 2}));
+        BOOST_TEST(it0 == v.begin());
 
         auto const it1 = v.insert(v.end(), a2.begin(), a2.end());
-        BOOST_CHECK(v == vec_type({0, 0, 1, 2, 3}));
-        BOOST_CHECK(it1 == v.begin() + 4);
+        BOOST_TEST(v == vec_type({0, 0, 1, 2, 3}));
+        BOOST_TEST(it1 == v.begin() + 4);
 
         auto const it2 = v.insert(v.begin() + 2, a3.begin(), a3.end());
-        BOOST_CHECK(v == vec_type({0, 0, 9, 9, 9, 1, 2, 3}));
-        BOOST_CHECK(it2 == v.begin() + 2);
+        BOOST_TEST(v == vec_type({0, 0, 9, 9, 9, 1, 2, 3}));
+        BOOST_TEST(it2 == v.begin() + 2);
     }
 
     {
@@ -543,13 +542,13 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         v.insert(v.begin(), i);
-        BOOST_CHECK(v == vec_type({0, 1, 2}));
+        BOOST_TEST(v == vec_type({0, 1, 2}));
 
         v.insert(v.end(), 3);
-        BOOST_CHECK(v == vec_type({0, 1, 2, 3}));
+        BOOST_TEST(v == vec_type({0, 1, 2, 3}));
 
         v.insert(v.begin() + 2, 9);
-        BOOST_CHECK(v == vec_type({0, 1, 9, 2, 3}));
+        BOOST_TEST(v == vec_type({0, 1, 9, 2, 3}));
     }
 
     {
@@ -562,13 +561,13 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         v.insert(v.begin(), 2, 0);
-        BOOST_CHECK(v == vec_type({0, 0, 1, 2}));
+        BOOST_TEST(v == vec_type({0, 0, 1, 2}));
 
         v.insert(v.end(), 1, 3);
-        BOOST_CHECK(v == vec_type({0, 0, 1, 2, 3}));
+        BOOST_TEST(v == vec_type({0, 0, 1, 2, 3}));
 
         v.insert(v.begin() + 2, 3, 9);
-        BOOST_CHECK(v == vec_type({0, 0, 9, 9, 9, 1, 2, 3}));
+        BOOST_TEST(v == vec_type({0, 0, 9, 9, 9, 1, 2, 3}));
     }
 
     {
@@ -581,18 +580,18 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         v.insert(v.begin(), std::initializer_list<int>{0, 0});
-        BOOST_CHECK(v == vec_type({0, 0, 1, 2}));
+        BOOST_TEST(v == vec_type({0, 0, 1, 2}));
 
         v.insert(v.end(), std::initializer_list<int>{3});
-        BOOST_CHECK(v == vec_type({0, 0, 1, 2, 3}));
+        BOOST_TEST(v == vec_type({0, 0, 1, 2, 3}));
 
         v.insert(v.begin() + 2, std::initializer_list<int>{9, 9, 9});
-        BOOST_CHECK(v == vec_type({0, 0, 9, 9, 9, 1, 2, 3}));
+        BOOST_TEST(v == vec_type({0, 0, 9, 9, 9, 1, 2, 3}));
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(erase)
+void test_erase()
 {
     {
         vec_type v = {3, 2, 1};
@@ -608,48 +607,48 @@ BOOST_AUTO_TEST_CASE(erase)
             "");
 
         v.erase(v.begin(), v.end());
-        BOOST_CHECK(v.empty());
-        BOOST_CHECK(v.size() == 0u);
+        BOOST_TEST(v.empty());
+        BOOST_TEST(v.size() == 0u);
     }
 
     {
         vec_type v = {3, 2, 1};
         v.erase(v.begin() + 1, v.end());
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 1u);
-        BOOST_CHECK(v == vec_type(1, 3));
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 1u);
+        BOOST_TEST(v == vec_type(1, 3));
     }
 
     {
         vec_type v = {3, 2, 1};
         v.erase(v.begin(), v.end() - 1);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 1u);
-        BOOST_CHECK(v == vec_type(1, 1));
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 1u);
+        BOOST_TEST(v == vec_type(1, 1));
     }
 
     {
         vec_type v = {3, 2, 1};
         v.erase(v.begin());
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 2u);
-        BOOST_CHECK(v == vec_type({2, 1}));
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 2u);
+        BOOST_TEST(v == vec_type({2, 1}));
     }
 
     {
         vec_type v = {3, 2, 1};
         v.erase(v.begin() + 1);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 2u);
-        BOOST_CHECK(v == vec_type({3, 1}));
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 2u);
+        BOOST_TEST(v == vec_type({3, 1}));
     }
 
     {
         vec_type v = {3, 2, 1};
         v.erase(v.begin() + 2);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 2u);
-        BOOST_CHECK(v == vec_type({3, 2}));
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 2u);
+        BOOST_TEST(v == vec_type({3, 2}));
     }
 }
 
@@ -669,7 +668,7 @@ static_assert(ill_formed<lvalue_push_front_t, vec_type>::value, "");
 static_assert(ill_formed<rvalue_push_front_t, vec_type>::value, "");
 static_assert(ill_formed<pop_front_t, vec_type>::value, "");
 
-BOOST_AUTO_TEST_CASE(front_back)
+void test_front_back()
 {
     {
         vec_type v;
@@ -680,32 +679,32 @@ BOOST_AUTO_TEST_CASE(front_back)
         static_assert(std::is_same<decltype(v.pop_back()), void>::value, "");
 
         v.push_back(i);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == i);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == i);
 
         v.push_back(1);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == 1);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == 1);
 
         v.push_back(2);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == 2);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == 2);
 
         static_assert(std::is_same<decltype(v.front()), int &>::value, "");
         static_assert(std::is_same<decltype(v.back()), int &>::value, "");
 
         v.front() = 9;
         v.back() = 8;
-        BOOST_CHECK(v == vec_type({9, 1, 8}));
+        BOOST_TEST(v == vec_type({9, 1, 8}));
 
         v.pop_back();
-        BOOST_CHECK(v == vec_type({9, 1}));
+        BOOST_TEST(v == vec_type({9, 1}));
     }
 
     {
         vec_type const v = {3, 2, 1};
-        BOOST_CHECK(v.front() == 3);
-        BOOST_CHECK(v.back() == 1);
+        BOOST_TEST(v.front() == 3);
+        BOOST_TEST(v.back() == 1);
 
         static_assert(
             std::is_same<decltype(v.front()), int const &>::value, "");
@@ -714,20 +713,20 @@ BOOST_AUTO_TEST_CASE(front_back)
 }
 
 
-BOOST_AUTO_TEST_CASE(data_index_at)
+void test_data_index_at()
 {
     {
         vec_type v = {3, 2, 1};
-        BOOST_CHECK(v.data()[0] == 3);
-        BOOST_CHECK(v.data()[1] == 2);
-        BOOST_CHECK(v.data()[2] == 1);
-        BOOST_CHECK(v[0] == 3);
-        BOOST_CHECK(v[1] == 2);
-        BOOST_CHECK(v[2] == 1);
-        BOOST_CHECK_NO_THROW(v.at(0));
-        BOOST_CHECK_NO_THROW(v.at(1));
-        BOOST_CHECK_NO_THROW(v.at(2));
-        BOOST_CHECK_THROW(v.at(3), std::out_of_range);
+        BOOST_TEST(v.data()[0] == 3);
+        BOOST_TEST(v.data()[1] == 2);
+        BOOST_TEST(v.data()[2] == 1);
+        BOOST_TEST(v[0] == 3);
+        BOOST_TEST(v[1] == 2);
+        BOOST_TEST(v[2] == 1);
+        BOOST_TEST_NO_THROW(v.at(0));
+        BOOST_TEST_NO_THROW(v.at(1));
+        BOOST_TEST_NO_THROW(v.at(2));
+        BOOST_TEST_THROWS(v.at(3), std::out_of_range);
 
         static_assert(std::is_same<decltype(v.data()), int *>::value, "");
         static_assert(std::is_same<decltype(v[0]), int &>::value, "");
@@ -735,24 +734,40 @@ BOOST_AUTO_TEST_CASE(data_index_at)
 
         v[0] = 8;
         v.at(1) = 9;
-        BOOST_CHECK(v == vec_type({8, 9, 1}));
+        BOOST_TEST(v == vec_type({8, 9, 1}));
     }
 
     {
         vec_type const v = {3, 2, 1};
-        BOOST_CHECK(v.data()[0] == 3);
-        BOOST_CHECK(v.data()[1] == 2);
-        BOOST_CHECK(v.data()[2] == 1);
-        BOOST_CHECK(v[0] == 3);
-        BOOST_CHECK(v[1] == 2);
-        BOOST_CHECK(v[2] == 1);
-        BOOST_CHECK_NO_THROW(v.at(0));
-        BOOST_CHECK_NO_THROW(v.at(1));
-        BOOST_CHECK_NO_THROW(v.at(2));
-        BOOST_CHECK_THROW(v.at(3), std::out_of_range);
+        BOOST_TEST(v.data()[0] == 3);
+        BOOST_TEST(v.data()[1] == 2);
+        BOOST_TEST(v.data()[2] == 1);
+        BOOST_TEST(v[0] == 3);
+        BOOST_TEST(v[1] == 2);
+        BOOST_TEST(v[2] == 1);
+        BOOST_TEST_NO_THROW(v.at(0));
+        BOOST_TEST_NO_THROW(v.at(1));
+        BOOST_TEST_NO_THROW(v.at(2));
+        BOOST_TEST_THROWS(v.at(3), std::out_of_range);
 
         static_assert(std::is_same<decltype(v.data()), int const *>::value, "");
         static_assert(std::is_same<decltype(v[0]), int const &>::value, "");
         static_assert(std::is_same<decltype(v.at(0)), int const &>::value, "");
     }
+}
+
+int main()
+{
+    test_default_ctor();
+    test_other_ctors_assign_ctor();
+    test_resize();
+    test_assignment_copy_move_equality();
+    test_comparisons();
+    test_swap();
+    test_iterators();
+    test_emplace_insert();
+    test_erase();
+    test_front_back();
+    test_data_index_at();
+    return boost::report_errors();
 }

--- a/test/static_vec_noncopyable.cpp
+++ b/test/static_vec_noncopyable.cpp
@@ -7,8 +7,7 @@
 
 #include "ill_formed.hpp"
 
-#define BOOST_TEST_MAIN
-#include <boost/test/included/unit_test.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 #include <array>
 
@@ -52,100 +51,100 @@ using vec_type = static_vector<noncopyable_int, 10>;
 #endif
 
 
-BOOST_AUTO_TEST_CASE(default_ctor)
+void test_default_ctor()
 {
     vec_type v;
-    BOOST_CHECK(v.empty());
-    BOOST_CHECK(v.size() == 0u);
+    BOOST_TEST(v.empty());
+    BOOST_TEST(v.size() == 0u);
 
 #if !USE_STD_VECTOR
-    BOOST_CHECK(v.max_size() == 10u);
-    BOOST_CHECK(v.capacity() == 10u);
+    BOOST_TEST(v.max_size() == 10u);
+    BOOST_TEST(v.capacity() == 10u);
 #endif
 
-    BOOST_CHECK(v == v);
-    BOOST_CHECK(v <= v);
-    BOOST_CHECK(v >= v);
+    BOOST_TEST(v == v);
+    BOOST_TEST(v <= v);
+    BOOST_TEST(v >= v);
 
-    BOOST_CHECK_THROW(v.at(0), std::out_of_range);
+    BOOST_TEST_THROWS(v.at(0), std::out_of_range);
 
     vec_type const & cv = v;
-    BOOST_CHECK(cv.empty());
-    BOOST_CHECK(cv.size() == 0u);
+    BOOST_TEST(cv.empty());
+    BOOST_TEST(cv.size() == 0u);
 
 #if !USE_STD_VECTOR
-    BOOST_CHECK(cv.max_size() == 10u);
-    BOOST_CHECK(cv.capacity() == 10u);
+    BOOST_TEST(cv.max_size() == 10u);
+    BOOST_TEST(cv.capacity() == 10u);
 #endif
 
-    BOOST_CHECK(cv == cv);
-    BOOST_CHECK(cv <= cv);
-    BOOST_CHECK(cv >= cv);
+    BOOST_TEST(cv == cv);
+    BOOST_TEST(cv <= cv);
+    BOOST_TEST(cv >= cv);
 
-    BOOST_CHECK_THROW(cv.at(0), std::out_of_range);
+    BOOST_TEST_THROWS(cv.at(0), std::out_of_range);
 }
 
 
-BOOST_AUTO_TEST_CASE(other_ctors_assign_ctor)
+void test_other_ctors_assign_ctor()
 {
     {
         vec_type v(3);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
     }
 
 #if 0 // initializer_list construction is not supported for move-only value_type.
         vec_type v2(std::initializer_list<noncopyable_int>{0, 0, 0});
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
 
     {
         std::initializer_list<noncopyable_int> il{3, 2, 1};
         vec_type v(il);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         static_assert(std::is_same<decltype(v = il), vec_type &>::value, "");
 
         vec_type v2;
         v2 = il;
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
         std::initializer_list<noncopyable_int> il{3, 2, 1};
         vec_type v;
         v.assign(il);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         static_assert(std::is_same<decltype(v.assign(il)), void>::value, "");
 
         vec_type v2;
         v2 = il;
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 #endif
 
 #if 0 // Code that boils down to fill-insert is not supported for move-only value_type.
     {
         vec_type v(3, 4);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         vec_type v2 = {4, 4, 4};
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
         vec_type v;
         v.assign(3, 4);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         static_assert(std::is_same<decltype(v.assign(3, 4)), void>::value, "");
 
         vec_type v2 = {4, 4, 4};
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 #endif
 
@@ -153,14 +152,14 @@ BOOST_AUTO_TEST_CASE(other_ctors_assign_ctor)
         std::array<int, 3> a = {{1, 2, 3}};
 
         vec_type v(a.begin(), a.end());
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         vec_type v2;
         v2.push_back(1);
         v2.push_back(2);
         v2.push_back(3);
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 
     {
@@ -168,8 +167,8 @@ BOOST_AUTO_TEST_CASE(other_ctors_assign_ctor)
 
         vec_type v;
         v.assign(a.begin(), a.end());
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 3u);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 3u);
 
         static_assert(
             std::is_same<decltype(v.assign(a.begin(), a.end())), void>::value,
@@ -179,12 +178,12 @@ BOOST_AUTO_TEST_CASE(other_ctors_assign_ctor)
         v2.push_back(1);
         v2.push_back(2);
         v2.push_back(3);
-        BOOST_CHECK(v == v2);
+        BOOST_TEST(v == v2);
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(resize)
+void test_resize()
 {
     {
         vec_type v;
@@ -192,25 +191,25 @@ BOOST_AUTO_TEST_CASE(resize)
         static_assert(std::is_same<decltype(v.resize(1)), void>::value, "");
 
         v.resize(3);
-        BOOST_CHECK(v == vec_type(3));
+        BOOST_TEST(v == vec_type(3));
 
         v.resize(6);
-        BOOST_CHECK(v == vec_type(6));
+        BOOST_TEST(v == vec_type(6));
     }
 
     {
         vec_type v(6);
 
         v.resize(3);
-        BOOST_CHECK(v == vec_type(3));
+        BOOST_TEST(v == vec_type(3));
 
         v.resize(0);
-        BOOST_CHECK(v == vec_type{});
+        BOOST_TEST(v == vec_type{});
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(assignment_copy_move_equality)
+void test_assignment_copy_move_equality()
 {
     {
         vec_type v2;
@@ -219,10 +218,10 @@ BOOST_AUTO_TEST_CASE(assignment_copy_move_equality)
         v2.push_back(4);
 
         vec_type v(std::move(v2));
-        BOOST_CHECK(v[0] == 4);
-        BOOST_CHECK(v[1] == 4);
-        BOOST_CHECK(v[2] == 4);
-        BOOST_CHECK(v2.empty());
+        BOOST_TEST(v[0] == 4);
+        BOOST_TEST(v[1] == 4);
+        BOOST_TEST(v[2] == 4);
+        BOOST_TEST(v2.empty());
     }
 
     {
@@ -233,15 +232,15 @@ BOOST_AUTO_TEST_CASE(assignment_copy_move_equality)
         v2.push_back(4);
 
         v = std::move(v2);
-        BOOST_CHECK(v[0] == 4);
-        BOOST_CHECK(v[1] == 4);
-        BOOST_CHECK(v[2] == 4);
-        BOOST_CHECK(v2.empty());
+        BOOST_TEST(v[0] == 4);
+        BOOST_TEST(v[1] == 4);
+        BOOST_TEST(v[2] == 4);
+        BOOST_TEST(v2.empty());
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(comparisons)
+void test_comparisons()
 {
     vec_type sm;
     sm.push_back(1);
@@ -259,75 +258,75 @@ BOOST_AUTO_TEST_CASE(comparisons)
     lg.push_back(4);
     lg.push_back(5);
 
-    BOOST_CHECK(sm == sm);
-    BOOST_CHECK(!(sm == md));
-    BOOST_CHECK(!(sm == lg));
+    BOOST_TEST(sm == sm);
+    BOOST_TEST(!(sm == md));
+    BOOST_TEST(!(sm == lg));
 
-    BOOST_CHECK(!(sm != sm));
-    BOOST_CHECK(sm != md);
-    BOOST_CHECK(sm != lg);
+    BOOST_TEST(!(sm != sm));
+    BOOST_TEST(sm != md);
+    BOOST_TEST(sm != lg);
 
-    BOOST_CHECK(!(sm < sm));
-    BOOST_CHECK(sm < md);
-    BOOST_CHECK(sm < lg);
+    BOOST_TEST(!(sm < sm));
+    BOOST_TEST(sm < md);
+    BOOST_TEST(sm < lg);
 
-    BOOST_CHECK(sm <= sm);
-    BOOST_CHECK(sm <= md);
-    BOOST_CHECK(sm <= lg);
+    BOOST_TEST(sm <= sm);
+    BOOST_TEST(sm <= md);
+    BOOST_TEST(sm <= lg);
 
-    BOOST_CHECK(!(sm > sm));
-    BOOST_CHECK(!(sm > md));
-    BOOST_CHECK(!(sm > lg));
+    BOOST_TEST(!(sm > sm));
+    BOOST_TEST(!(sm > md));
+    BOOST_TEST(!(sm > lg));
 
-    BOOST_CHECK(sm >= sm);
-    BOOST_CHECK(!(sm >= md));
-    BOOST_CHECK(!(sm >= lg));
-
-
-    BOOST_CHECK(!(md == sm));
-    BOOST_CHECK(md == md);
-    BOOST_CHECK(!(md == lg));
-
-    BOOST_CHECK(!(md < sm));
-    BOOST_CHECK(!(md < md));
-    BOOST_CHECK(md < lg);
-
-    BOOST_CHECK(!(md <= sm));
-    BOOST_CHECK(md <= md);
-    BOOST_CHECK(md <= lg);
-
-    BOOST_CHECK(md > sm);
-    BOOST_CHECK(!(md > md));
-    BOOST_CHECK(!(md > lg));
-
-    BOOST_CHECK(md >= sm);
-    BOOST_CHECK(md >= md);
-    BOOST_CHECK(!(md >= lg));
+    BOOST_TEST(sm >= sm);
+    BOOST_TEST(!(sm >= md));
+    BOOST_TEST(!(sm >= lg));
 
 
-    BOOST_CHECK(!(lg == sm));
-    BOOST_CHECK(!(lg == md));
-    BOOST_CHECK(lg == lg);
+    BOOST_TEST(!(md == sm));
+    BOOST_TEST(md == md);
+    BOOST_TEST(!(md == lg));
 
-    BOOST_CHECK(!(lg < sm));
-    BOOST_CHECK(!(lg < md));
-    BOOST_CHECK(!(lg < lg));
+    BOOST_TEST(!(md < sm));
+    BOOST_TEST(!(md < md));
+    BOOST_TEST(md < lg);
 
-    BOOST_CHECK(!(lg <= sm));
-    BOOST_CHECK(!(lg <= md));
-    BOOST_CHECK(lg <= lg);
+    BOOST_TEST(!(md <= sm));
+    BOOST_TEST(md <= md);
+    BOOST_TEST(md <= lg);
 
-    BOOST_CHECK(lg > sm);
-    BOOST_CHECK(lg > md);
-    BOOST_CHECK(!(lg > lg));
+    BOOST_TEST(md > sm);
+    BOOST_TEST(!(md > md));
+    BOOST_TEST(!(md > lg));
 
-    BOOST_CHECK(lg >= sm);
-    BOOST_CHECK(lg >= md);
-    BOOST_CHECK(lg >= lg);
+    BOOST_TEST(md >= sm);
+    BOOST_TEST(md >= md);
+    BOOST_TEST(!(md >= lg));
+
+
+    BOOST_TEST(!(lg == sm));
+    BOOST_TEST(!(lg == md));
+    BOOST_TEST(lg == lg);
+
+    BOOST_TEST(!(lg < sm));
+    BOOST_TEST(!(lg < md));
+    BOOST_TEST(!(lg < lg));
+
+    BOOST_TEST(!(lg <= sm));
+    BOOST_TEST(!(lg <= md));
+    BOOST_TEST(lg <= lg);
+
+    BOOST_TEST(lg > sm);
+    BOOST_TEST(lg > md);
+    BOOST_TEST(!(lg > lg));
+
+    BOOST_TEST(lg >= sm);
+    BOOST_TEST(lg >= md);
+    BOOST_TEST(lg >= lg);
 }
 
 
-BOOST_AUTO_TEST_CASE(swap_)
+void test_swap()
 {
     {
         vec_type v1;
@@ -345,11 +344,11 @@ BOOST_AUTO_TEST_CASE(swap_)
 
         v1.swap(v2);
 
-        BOOST_CHECK(v1.size() == 4u);
-        BOOST_CHECK(v2.size() == 3u);
+        BOOST_TEST(v1.size() == 4u);
+        BOOST_TEST(v2.size() == 3u);
 
-        BOOST_CHECK(v1[0] == 3);
-        BOOST_CHECK(v2[0] == 4);
+        BOOST_TEST(v1[0] == 3);
+        BOOST_TEST(v2[0] == 4);
     }
 
     {
@@ -365,11 +364,11 @@ BOOST_AUTO_TEST_CASE(swap_)
 
         swap(v1, v2);
 
-        BOOST_CHECK(v1.size() == 4u);
-        BOOST_CHECK(v2.size() == 3u);
+        BOOST_TEST(v1.size() == 4u);
+        BOOST_TEST(v2.size() == 3u);
 
-        BOOST_CHECK(v1[0] == 3);
-        BOOST_CHECK(v2[0] == 4);
+        BOOST_TEST(v1[0] == 3);
+        BOOST_TEST(v2[0] == 4);
     }
 }
 
@@ -417,7 +416,7 @@ static_assert(
         value,
     "");
 
-BOOST_AUTO_TEST_CASE(iterators)
+void test_iterators()
 {
     {
         vec_type v;
@@ -457,16 +456,16 @@ BOOST_AUTO_TEST_CASE(iterators)
         std::array<int, 3> const a = {{3, 2, 1}};
 	std::array<int, 3> const ra = {{1, 2, 3}};
 
-        BOOST_CHECK(std::equal(v.begin(), v.end(), a.begin(), a.end()));
-        BOOST_CHECK(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.begin(), v.end(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
 
-        BOOST_CHECK(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
-        BOOST_CHECK(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
 
         *v.begin() = 8;
         *v.rbegin() = 9;
-        BOOST_CHECK(v[0] == 8);
-        BOOST_CHECK(v[2] == 9);
+        BOOST_TEST(v[0] == 8);
+        BOOST_TEST(v[2] == 9);
     }
 
     {
@@ -512,16 +511,16 @@ BOOST_AUTO_TEST_CASE(iterators)
         std::array<int, 3> const a = {{3, 2, 1}};
         std::array<int, 3> const ra = {{1, 2, 3}};
 
-        BOOST_CHECK(std::equal(v.begin(), v.end(), a.begin(), a.end()));
-        BOOST_CHECK(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.begin(), v.end(), a.begin(), a.end()));
+        BOOST_TEST(std::equal(v.cbegin(), v.cend(), a.begin(), a.end()));
 
-        BOOST_CHECK(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
-        BOOST_CHECK(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.rbegin(), v.rend(), ra.begin(), ra.end()));
+        BOOST_TEST(std::equal(v.crbegin(), v.crend(), ra.begin(), ra.end()));
     }
 }
 
 
-BOOST_AUTO_TEST_CASE(emplace_insert)
+void test_emplace_insert()
 {
     {
         vec_type v;
@@ -537,20 +536,20 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         v.emplace_back(i);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == i);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == i);
 
         v.emplace_back(1);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == 1);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == 1);
 
         v.emplace_back(2);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == 2);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == 2);
 
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 1);
-        BOOST_CHECK(v[2] == 2);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 1);
+        BOOST_TEST(v[2] == 2);
     }
 
     {
@@ -571,22 +570,22 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         v.emplace(v.begin(), i);
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 1);
-        BOOST_CHECK(v[2] == 2);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 1);
+        BOOST_TEST(v[2] == 2);
 
         v.emplace(v.end(), 3);
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 1);
-        BOOST_CHECK(v[2] == 2);
-        BOOST_CHECK(v[3] == 3);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 1);
+        BOOST_TEST(v[2] == 2);
+        BOOST_TEST(v[3] == 3);
 
         v.emplace(v.begin() + 2, 9);
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 1);
-        BOOST_CHECK(v[2] == 9);
-        BOOST_CHECK(v[3] == 2);
-        BOOST_CHECK(v[4] == 3);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 1);
+        BOOST_TEST(v[2] == 9);
+        BOOST_TEST(v[3] == 2);
+        BOOST_TEST(v[4] == 3);
     }
 
     {
@@ -605,30 +604,30 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         auto const it0 = v.insert(v.begin(), a1.begin(), a1.end());
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 0);
-        BOOST_CHECK(v[2] == 1);
-        BOOST_CHECK(v[3] == 2);
-        BOOST_CHECK(it0 == v.begin());
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 0);
+        BOOST_TEST(v[2] == 1);
+        BOOST_TEST(v[3] == 2);
+        BOOST_TEST(it0 == v.begin());
 
         auto const it1 = v.insert(v.end(), a2.begin(), a2.end());
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 0);
-        BOOST_CHECK(v[2] == 1);
-        BOOST_CHECK(v[3] == 2);
-        BOOST_CHECK(v[4] == 3);
-        BOOST_CHECK(it1 == v.begin() + 4);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 0);
+        BOOST_TEST(v[2] == 1);
+        BOOST_TEST(v[3] == 2);
+        BOOST_TEST(v[4] == 3);
+        BOOST_TEST(it1 == v.begin() + 4);
 
         auto const it2 = v.insert(v.begin() + 2, a3.begin(), a3.end());
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 0);
-        BOOST_CHECK(v[2] == 9);
-        BOOST_CHECK(v[3] == 9);
-        BOOST_CHECK(v[4] == 9);
-        BOOST_CHECK(v[5] == 1);
-        BOOST_CHECK(v[6] == 2);
-        BOOST_CHECK(v[7] == 3);
-        BOOST_CHECK(it2 == v.begin() + 2);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 0);
+        BOOST_TEST(v[2] == 9);
+        BOOST_TEST(v[3] == 9);
+        BOOST_TEST(v[4] == 9);
+        BOOST_TEST(v[5] == 1);
+        BOOST_TEST(v[6] == 2);
+        BOOST_TEST(v[7] == 3);
+        BOOST_TEST(it2 == v.begin() + 2);
     }
 
     {
@@ -647,22 +646,22 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
             "");
 
         v.emplace(v.begin(), i);
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 1);
-        BOOST_CHECK(v[2] == 2);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 1);
+        BOOST_TEST(v[2] == 2);
 
         v.emplace(v.end(), 3);
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 1);
-        BOOST_CHECK(v[2] == 2);
-        BOOST_CHECK(v[3] == 3);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 1);
+        BOOST_TEST(v[2] == 2);
+        BOOST_TEST(v[3] == 3);
 
         v.emplace(v.begin() + 2, 9);
-        BOOST_CHECK(v[0] == 0);
-        BOOST_CHECK(v[1] == 1);
-        BOOST_CHECK(v[2] == 9);
-        BOOST_CHECK(v[3] == 2);
-        BOOST_CHECK(v[4] == 3);
+        BOOST_TEST(v[0] == 0);
+        BOOST_TEST(v[1] == 1);
+        BOOST_TEST(v[2] == 9);
+        BOOST_TEST(v[3] == 2);
+        BOOST_TEST(v[4] == 3);
     }
 
 #if 0 // Fill-insert is not supported for move-only value_type.
@@ -703,7 +702,7 @@ BOOST_AUTO_TEST_CASE(emplace_insert)
 }
 
 
-BOOST_AUTO_TEST_CASE(erase)
+void test_erase()
 {
     {
         vec_type v;
@@ -722,8 +721,8 @@ BOOST_AUTO_TEST_CASE(erase)
             "");
 
         v.erase(v.begin(), v.end());
-        BOOST_CHECK(v.empty());
-        BOOST_CHECK(v.size() == 0u);
+        BOOST_TEST(v.empty());
+        BOOST_TEST(v.size() == 0u);
     }
 
     {
@@ -732,9 +731,9 @@ BOOST_AUTO_TEST_CASE(erase)
         v.push_back(2);
         v.push_back(1);
         v.erase(v.begin() + 1, v.end());
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 1u);
-        BOOST_CHECK(v[0] == 3);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 1u);
+        BOOST_TEST(v[0] == 3);
     }
 
     {
@@ -743,9 +742,9 @@ BOOST_AUTO_TEST_CASE(erase)
         v.push_back(2);
         v.push_back(1);
         v.erase(v.begin(), v.end() - 1);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 1u);
-        BOOST_CHECK(v[0] == 1);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 1u);
+        BOOST_TEST(v[0] == 1);
     }
 
     {
@@ -754,10 +753,10 @@ BOOST_AUTO_TEST_CASE(erase)
         v.push_back(2);
         v.push_back(1);
         v.erase(v.begin());
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 2u);
-        BOOST_CHECK(v[0] == 2);
-        BOOST_CHECK(v[1] == 1);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 2u);
+        BOOST_TEST(v[0] == 2);
+        BOOST_TEST(v[1] == 1);
     }
 
     {
@@ -766,10 +765,10 @@ BOOST_AUTO_TEST_CASE(erase)
         v.push_back(2);
         v.push_back(1);
         v.erase(v.begin() + 1);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 2u);
-        BOOST_CHECK(v[0] == 3);
-        BOOST_CHECK(v[1] == 1);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 2u);
+        BOOST_TEST(v[0] == 3);
+        BOOST_TEST(v[1] == 1);
     }
 
     {
@@ -778,10 +777,10 @@ BOOST_AUTO_TEST_CASE(erase)
         v.push_back(2);
         v.push_back(1);
         v.erase(v.begin() + 2);
-        BOOST_CHECK(!v.empty());
-        BOOST_CHECK(v.size() == 2u);
-        BOOST_CHECK(v[0] == 3);
-        BOOST_CHECK(v[1] == 2);
+        BOOST_TEST(!v.empty());
+        BOOST_TEST(v.size() == 2u);
+        BOOST_TEST(v[0] == 3);
+        BOOST_TEST(v[1] == 2);
     }
 }
 
@@ -801,7 +800,7 @@ static_assert(ill_formed<lvalue_push_front_t, vec_type>::value, "");
 static_assert(ill_formed<rvalue_push_front_t, vec_type>::value, "");
 static_assert(ill_formed<pop_front_t, vec_type>::value, "");
 
-BOOST_AUTO_TEST_CASE(front_back)
+void test_front_back()
 {
     {
         vec_type v;
@@ -812,29 +811,29 @@ BOOST_AUTO_TEST_CASE(front_back)
         static_assert(std::is_same<decltype(v.pop_back()), void>::value, "");
 
         v.emplace_back(i);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == i);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == i);
 
         v.emplace_back(1);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == 1);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == 1);
 
         v.emplace_back(2);
-        BOOST_CHECK(v.front() == i);
-        BOOST_CHECK(v.back() == 2);
+        BOOST_TEST(v.front() == i);
+        BOOST_TEST(v.back() == 2);
 
         static_assert(std::is_same<decltype(v.front()), noncopyable_int &>::value, "");
         static_assert(std::is_same<decltype(v.back()), noncopyable_int &>::value, "");
 
         v.front() = 9;
         v.back() = 8;
-        BOOST_CHECK(v[0] == 9);
-        BOOST_CHECK(v[1] == 1);
-        BOOST_CHECK(v[2] == 8);
+        BOOST_TEST(v[0] == 9);
+        BOOST_TEST(v[1] == 1);
+        BOOST_TEST(v[2] == 8);
 
         v.pop_back();
-        BOOST_CHECK(v[0] == 9);
-        BOOST_CHECK(v[1] == 1);
+        BOOST_TEST(v[0] == 9);
+        BOOST_TEST(v[1] == 1);
     }
 
     {
@@ -843,8 +842,8 @@ BOOST_AUTO_TEST_CASE(front_back)
         v_.push_back(2);
         v_.push_back(1);
         vec_type const & v = v_;
-        BOOST_CHECK(v.front() == 3);
-        BOOST_CHECK(v.back() == 1);
+        BOOST_TEST(v.front() == 3);
+        BOOST_TEST(v.back() == 1);
 
         static_assert(
             std::is_same<decltype(v.front()), noncopyable_int const &>::value, "");
@@ -853,23 +852,23 @@ BOOST_AUTO_TEST_CASE(front_back)
 }
 
 
-BOOST_AUTO_TEST_CASE(data_index_at)
+void test_data_index_at()
 {
     {
         vec_type v;
         v.push_back(3);
         v.push_back(2);
         v.push_back(1);
-        BOOST_CHECK(v.data()[0] == 3);
-        BOOST_CHECK(v.data()[1] == 2);
-        BOOST_CHECK(v.data()[2] == 1);
-        BOOST_CHECK(v[0] == 3);
-        BOOST_CHECK(v[1] == 2);
-        BOOST_CHECK(v[2] == 1);
-        BOOST_CHECK_NO_THROW(v.at(0));
-        BOOST_CHECK_NO_THROW(v.at(1));
-        BOOST_CHECK_NO_THROW(v.at(2));
-        BOOST_CHECK_THROW(v.at(3), std::out_of_range);
+        BOOST_TEST(v.data()[0] == 3);
+        BOOST_TEST(v.data()[1] == 2);
+        BOOST_TEST(v.data()[2] == 1);
+        BOOST_TEST(v[0] == 3);
+        BOOST_TEST(v[1] == 2);
+        BOOST_TEST(v[2] == 1);
+        BOOST_TEST_NO_THROW(v.at(0));
+        BOOST_TEST_NO_THROW(v.at(1));
+        BOOST_TEST_NO_THROW(v.at(2));
+        BOOST_TEST_THROWS(v.at(3), std::out_of_range);
 
         static_assert(std::is_same<decltype(v.data()), noncopyable_int *>::value, "");
         static_assert(std::is_same<decltype(v[0]), noncopyable_int &>::value, "");
@@ -877,9 +876,9 @@ BOOST_AUTO_TEST_CASE(data_index_at)
 
         v[0] = 8;
         v.at(1) = 9;
-        BOOST_CHECK(v[0] == 8);
-        BOOST_CHECK(v[1] == 9);
-        BOOST_CHECK(v[2] == 1);
+        BOOST_TEST(v[0] == 8);
+        BOOST_TEST(v[1] == 9);
+        BOOST_TEST(v[2] == 1);
     }
 
     {
@@ -888,19 +887,35 @@ BOOST_AUTO_TEST_CASE(data_index_at)
         v_.push_back(2);
         v_.push_back(1);
         vec_type const & v = v_;
-        BOOST_CHECK(v.data()[0] == 3);
-        BOOST_CHECK(v.data()[1] == 2);
-        BOOST_CHECK(v.data()[2] == 1);
-        BOOST_CHECK(v[0] == 3);
-        BOOST_CHECK(v[1] == 2);
-        BOOST_CHECK(v[2] == 1);
-        BOOST_CHECK_NO_THROW(v.at(0));
-        BOOST_CHECK_NO_THROW(v.at(1));
-        BOOST_CHECK_NO_THROW(v.at(2));
-        BOOST_CHECK_THROW(v.at(3), std::out_of_range);
+        BOOST_TEST(v.data()[0] == 3);
+        BOOST_TEST(v.data()[1] == 2);
+        BOOST_TEST(v.data()[2] == 1);
+        BOOST_TEST(v[0] == 3);
+        BOOST_TEST(v[1] == 2);
+        BOOST_TEST(v[2] == 1);
+        BOOST_TEST_NO_THROW(v.at(0));
+        BOOST_TEST_NO_THROW(v.at(1));
+        BOOST_TEST_NO_THROW(v.at(2));
+        BOOST_TEST_THROWS(v.at(3), std::out_of_range);
 
         static_assert(std::is_same<decltype(v.data()), noncopyable_int const *>::value, "");
         static_assert(std::is_same<decltype(v[0]), noncopyable_int const &>::value, "");
         static_assert(std::is_same<decltype(v.at(0)), noncopyable_int const &>::value, "");
     }
+}
+
+int main()
+{
+    test_default_ctor();
+    test_other_ctors_assign_ctor();
+    test_resize();
+    test_assignment_copy_move_equality();
+    test_comparisons();
+    test_swap();
+    test_iterators();
+    test_emplace_insert();
+    test_erase();
+    test_front_back();
+    test_data_index_at();
+    return boost::report_errors();
 }


### PR DESCRIPTION
The dependencies for testing decrease significantly (as shown in the `cmake/dependencies.cmake` diff) as does the time to build and run the tests.