### PR TITLE
Update metadata

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -1,6 +1,6 @@
 {
     "key": "stl_interfaces",
-    "name": "stl_interfaces",
+    "name": "Stl_interfaces",
     "authors": [ "T. Zachary Laine" ],
     "maintainers": [ "Zach Laine <whatwasthataddress -at- gmail.com>" ],
     "description": "C++14 and later CRTP templates for defining iterators, views, and containers.",


### PR DESCRIPTION
To match the pattern other boost libraries are using, the "name" field is capitalized and corresponds to what is shown on boost.org. 

another option could be:

```
"name": "STL Interfaces"
```
