### PR TITLE
Return derived() from operator--() in iterator_interface.

### DIFF
--- a/include/boost/stl_interfaces/iterator_interface.hpp
+++ b/include/boost/stl_interfaces/iterator_interface.hpp
@@ -381,9 +381,10 @@ namespace boost { namespace stl_interfaces { BOOST_STL_INTERFACES_NAMESPACE_V1 {
                 std::enable_if_t<!v1_dtl::plus_eq<D, difference_type>::value>>
         constexpr auto
         operator--() noexcept(noexcept(--access::base(std::declval<D &>())))
-            -> decltype(--access::base(std::declval<D &>()))
+            -> decltype(--access::base(std::declval<D &>()), std::declval<D &>())
         {
-            return --access::base(derived());
+            --access::base(derived());
+            return derived();
         }
 
         template<typename D = Derived>


### PR DESCRIPTION
Previously, this returned the underlying adapted iterator.
Fixes #50.