### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,18 +5,21 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/stl_interfaces
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_stl_interfaces ]
+    [ alias boost_stl_interfaces : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_stl_interfaces test ]
     ;
 
 call-if : boost-library stl_interfaces
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,9 +7,9 @@ import project ;
 
 project /boost/stl_interfaces
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,22 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/stl_interfaces
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_stl_interfaces ]
+    [ alias all : boost_stl_interfaces test ]
+    ;
+
+call-if : boost-library stl_interfaces
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/stl_interfaces
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/stl_interfaces

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -39,7 +39,7 @@ rule run_doxygen ( files * : name : expand ? )
 
 }
 
-run_doxygen [ glob $(here)/../../../boost/stl_interfaces/*.hpp ] : "Headers" ;
+run_doxygen [ glob $(here)/../include/boost/stl_interfaces/*.hpp ] : "Headers" ;
 
 install images_standalone : [ glob *.png ] : <location>html/stl_interfaces/img ;
 explicit images_standalone ;

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -7,6 +7,7 @@
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 import testing ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 project :

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -12,7 +12,7 @@ import config : requires ;
 
 project :
     requirements
-        <source>/boost/core//boost_core
+        <library>/boost/core//boost_core
         [ requires cxx14_constexpr ]
 ;
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -7,10 +7,11 @@
 #          http://www.boost.org/LICENSE_1_0.txt)
 
 import testing ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 project :
     requirements
+        <source>/boost/core//boost_core
         [ requires cxx14_constexpr ]
 ;
 


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.