### PR TITLE
Enable BOOST_STL_INTERFACES_USE_DEDUCED_THIS on Clang 19 and MSVC 19.41

### DIFF
--- a/include/boost/stl_interfaces/config.hpp
+++ b/include/boost/stl_interfaces/config.hpp
@@ -6,6 +6,9 @@
 #ifndef BOOST_STL_INTERFACES_CONFIG_HPP
 #define BOOST_STL_INTERFACES_CONFIG_HPP
 
+// Included for BOOST_CLANG_VERSION
+#include <boost/config.hpp>
+
 // Included for definition of __cpp_lib_concepts.
 #include <iterator>
 
@@ -17,7 +20,9 @@
 #define BOOST_STL_INTERFACES_USE_CONCEPTS 0
 #endif
 
-#if defined(__cpp_explicit_this_parameter) &&                                  \
+#if (defined(__cpp_explicit_this_parameter) ||                                 \
+     (defined(_MSC_VER) && _MSC_VER >= 1941) ||                                \
+     (defined(BOOST_CLANG_VERSION) && BOOST_CLANG_VERSION >= 190000)) &&       \
     BOOST_STL_INTERFACES_USE_CONCEPTS &&                                       \
     !defined(BOOST_STL_INTERFACES_DISABLE_DEDUCED_THIS)
 #define BOOST_STL_INTERFACES_USE_DEDUCED_THIS 1


### PR DESCRIPTION
Clang 19 and MSVC 17.11.35222.181 both have support for deducing this that is complete enough to allow the v3 version of this library to work but not complete enough for the compilers to define __cpp_explicit_this_parameter. By adding
BOOST_STL_INTERFACES_ENABLE_DEDUCED_THIS, users of those compilers can explicitly opt into the v3 interface even when their compilers do not advertise support for deducing this.

BOOST_STL_INTERFACES_ENABLE_CONCEPTS is added for symmetry.